### PR TITLE
Fix Migration Column order

### DIFF
--- a/kottage/data/sqlite/src/commonMain/sqldelight/io/github/irgaly/kottage/data/sqlite/item.sq
+++ b/kottage/data/sqlite/src/commonMain/sqldelight/io/github/irgaly/kottage/data/sqlite/item.sq
@@ -15,7 +15,7 @@ CREATE INDEX item_type_last_read ON item(type, last_read_at);
 CREATE INDEX item_type_expire_at ON item(type, expire_at);
 
 replace:
-REPLACE INTO item VALUES ?;
+REPLACE INTO item(key, type, string_value, long_value, double_value, bytes_value, created_at, last_read_at, expire_at) VALUES ?;
 
 updateLastRead:
 UPDATE item SET last_read_at = ? WHERE key = ?;
@@ -24,7 +24,7 @@ updateExpireAt:
 UPDATE item SET expire_at = ? WHERE key = ?;
 
 select:
-SELECT * FROM item WHERE key = ?;
+SELECT key, type, string_value, long_value, double_value, bytes_value, created_at, last_read_at, expire_at FROM item WHERE key = ?;
 
 selectKey:
 SELECT key FROM item WHERE key = ?;

--- a/kottage/data/sqlite/src/commonMain/sqldelight/io/github/irgaly/kottage/data/sqlite/item_event.sq
+++ b/kottage/data/sqlite/src/commonMain/sqldelight/io/github/irgaly/kottage/data/sqlite/item_event.sq
@@ -17,19 +17,19 @@ CREATE INDEX item_event_item_list_type_created_at ON item_event(item_list_type, 
 CREATE INDEX item_event_item_list_type_expire_at ON item_event(item_list_type, expire_at);
 
 insert:
-INSERT INTO item_event VALUES ?;
+INSERT INTO item_event(id, created_at, expire_at, item_type, item_key, item_list_id, item_list_type, event_type) VALUES ?;
 
 selectAfterCreatedAt:
-SELECT * FROM item_event WHERE ? < created_at ORDER BY created_at ASC;
+SELECT id, created_at, expire_at, item_type, item_key, item_list_id, item_list_type, event_type FROM item_event WHERE ? < created_at ORDER BY created_at ASC;
 
 selectAfterCreatedAtLimit:
-SELECT * FROM item_event WHERE ? < created_at ORDER BY created_at ASC LIMIT :limit;
+SELECT id, created_at, expire_at, item_type, item_key, item_list_id, item_list_type, event_type FROM item_event WHERE ? < created_at ORDER BY created_at ASC LIMIT :limit;
 
 selectItemTypeAfterCreatedAt:
-SELECT * FROM item_event WHERE item_type = ? AND ? < created_at ORDER BY created_at ASC;
+SELECT id, created_at, expire_at, item_type, item_key, item_list_id, item_list_type, event_type FROM item_event WHERE item_type = ? AND ? < created_at ORDER BY created_at ASC;
 
 selectItemTypeAfterCreatedAtLimit:
-SELECT * FROM item_event WHERE item_type = ? AND ? < created_at ORDER BY created_at ASC LIMIT :limit;
+SELECT id, created_at, expire_at, item_type, item_key, item_list_id, item_list_type, event_type FROM item_event WHERE item_type = ? AND ? < created_at ORDER BY created_at ASC LIMIT :limit;
 
 selectItemTypeLatestCreatedAt:
 SELECT created_at FROM item_event WHERE item_type = ? ORDER BY created_at DESC LIMIT 1;

--- a/kottage/data/sqlite/src/commonMain/sqldelight/io/github/irgaly/kottage/data/sqlite/item_list.sq
+++ b/kottage/data/sqlite/src/commonMain/sqldelight/io/github/irgaly/kottage/data/sqlite/item_list.sq
@@ -16,7 +16,7 @@ CREATE INDEX item_list_item_type_item_key ON item_list(item_type, item_key);
 CREATE INDEX item_list_type_item_type_expire_at ON item_list(type, item_type, expire_at);
 
 replace:
-REPLACE INTO item_list VALUES ?;
+REPLACE INTO item_list(id, type, item_type, item_key, previous_id, next_id, expire_at, user_info, user_previous_key, user_current_key, user_next_key) VALUES ?;
 
 updatePreviousId:
 UPDATE item_list SET previous_id = ? WHERE id = ?;
@@ -37,7 +37,7 @@ removeUserData:
 UPDATE item_list SET user_info = NULL, user_previous_key = NULL, user_current_key = NULL, user_next_key = NULL WHERE id = ?;
 
 select:
-SELECT * FROM item_list WHERE id = ?;
+SELECT id, type, item_type, item_key, previous_id, next_id, expire_at, user_info, user_previous_key, user_current_key, user_next_key FROM item_list WHERE id = ?;
 
 selectIdFromItem:
 SELECT id FROM item_list WHERE item_type = ? AND item_key = ?;

--- a/kottage/data/sqlite/src/commonMain/sqldelight/io/github/irgaly/kottage/data/sqlite/item_list_stats.sq
+++ b/kottage/data/sqlite/src/commonMain/sqldelight/io/github/irgaly/kottage/data/sqlite/item_list_stats.sq
@@ -6,7 +6,7 @@ CREATE TABLE item_list_stats (
 );
 
 insert:
-INSERT INTO item_list_stats(item_list_type, count, first_item_list_id, last_item_list_id) VALUES(?, ?, ?, ?);
+INSERT INTO item_list_stats(item_list_type, count, first_item_list_id, last_item_list_id) VALUES ?;
 
 updateFirstItemListId:
 UPDATE item_list_stats SET first_item_list_id = ? WHERE item_list_type = ?;
@@ -24,7 +24,7 @@ updateCount:
 UPDATE item_list_stats SET count = ? WHERE item_list_type = ?;
 
 select:
-SELECT * FROM item_list_stats WHERE item_list_type = ?;
+SELECT item_list_type, count, first_item_list_id, last_item_list_id FROM item_list_stats WHERE item_list_type = ?;
 
 selectAllItemListType:
 SELECT item_list_type FROM item_list_stats;

--- a/kottage/data/sqlite/src/commonMain/sqldelight/io/github/irgaly/kottage/data/sqlite/item_stats.sq
+++ b/kottage/data/sqlite/src/commonMain/sqldelight/io/github/irgaly/kottage/data/sqlite/item_stats.sq
@@ -8,7 +8,7 @@ insertIfNotExists:
 INSERT OR IGNORE INTO item_stats(item_type) VALUES(?);
 
 select:
-SELECT * FROM item_stats WHERE item_type = ?;
+SELECT item_type, count, event_count FROM item_stats WHERE item_type = ?;
 
 incrementCount:
 UPDATE item_stats SET count = count + ? WHERE item_type = ?;

--- a/kottage/data/sqlite/src/commonMain/sqldelight/io/github/irgaly/kottage/data/sqlite/stats.sq
+++ b/kottage/data/sqlite/src/commonMain/sqldelight/io/github/irgaly/kottage/data/sqlite/stats.sq
@@ -4,7 +4,7 @@ CREATE TABLE stats (
 );
 
 insertIfNotExists:
-INSERT OR IGNORE INTO stats VALUES(?, 0);
+INSERT OR IGNORE INTO stats(key, last_evict_at) VALUES(?, 0);
 
 selectLastEvictAt:
 SELECT last_evict_at FROM stats WHERE key = ?;

--- a/kottage/src/commonSqliteMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageSqliteItemListRepository.kt
+++ b/kottage/src/commonSqliteMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageSqliteItemListRepository.kt
@@ -1,6 +1,7 @@
 package io.github.irgaly.kottage.internal.repository
 
 import com.squareup.sqldelight.db.use
+import io.github.irgaly.kottage.data.sqlite.Item_list_stats
 import io.github.irgaly.kottage.data.sqlite.KottageDatabase
 import io.github.irgaly.kottage.internal.model.ItemListEntry
 import io.github.irgaly.kottage.internal.model.ItemListStats
@@ -133,10 +134,12 @@ internal class KottageSqliteItemListRepository(
     ) {
         database.item_list_statsQueries
             .insert(
-                item_list_type = type,
-                count = count,
-                first_item_list_id = firstItemListEntryId,
-                last_item_list_id = lastItemListEntryId
+                Item_list_stats(
+                    item_list_type = type,
+                    count = count,
+                    first_item_list_id = firstItemListEntryId,
+                    last_item_list_id = lastItemListEntryId
+                )
             )
     }
 

--- a/kottage/src/commonTest/kotlin/io/github/irgaly/kottage/KottageMigrationTest.kt
+++ b/kottage/src/commonTest/kotlin/io/github/irgaly/kottage/KottageMigrationTest.kt
@@ -15,17 +15,17 @@ class KottageMigrationTest : DescribeSpec({
                 println("tempDirectory = $tempDirectory")
             }
         }
-        context("1 ->") {
+        context("from 1") {
             val calendar = TestCalendar(DateTime(2022, 1, 1).utc)
             val environment = KottageEnvironment(KottageContext(), calendar)
-            it("-> 2") {
+            it("to 2") {
                 Kottage.createOldDatabase(
                     "test",
                     tempDirectory,
                     environment,
                     1
                 )
-                val kottage = Kottage( "test", tempDirectory, environment)
+                val kottage = Kottage("test", tempDirectory, environment)
                 val cache = kottage.cache("cache1")
                 cache.put("key2", "value2")
                 cache.get<String>("key1") shouldBe "value1"

--- a/kottage/src/commonTest/kotlin/io/github/irgaly/kottage/KottageMigrationTest.kt
+++ b/kottage/src/commonTest/kotlin/io/github/irgaly/kottage/KottageMigrationTest.kt
@@ -27,7 +27,9 @@ class KottageMigrationTest : DescribeSpec({
                 )
                 val kottage = Kottage( "test", tempDirectory, environment)
                 val cache = kottage.cache("cache1")
+                cache.put("key2", "value2")
                 cache.get<String>("key1") shouldBe "value1"
+                cache.get<String>("key2") shouldBe "value2"
             }
         }
     }


### PR DESCRIPTION
fixes #31

Schema を v1 から v2 へマイグレーションすると Column の順番が変わってしまうために、SELECT と INSERT VALUES の並びが不正となっていた。

v2 Schema からデータベースを作成していれば問題ない。
将来的な潜在バグとならないように Column の並びは必ず指定する。