### PR TITLE
implement: KottageStorage.property()

### DIFF
--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/KottageStorage.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/KottageStorage.kt
@@ -1,7 +1,9 @@
 package io.github.irgaly.kottage
 
+import io.github.irgaly.kottage.property.KottageStore
 import kotlinx.serialization.SerializationException
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf
 import kotlin.time.Duration
@@ -97,6 +99,19 @@ interface KottageStorage {
         optionsBuilder: (KottageListOptions.Builder.() -> Unit)? = null
     ): KottageList
 
+    fun <T : Any> property(
+        type: KType,
+        key: String? = null,
+        expireTime: Duration? = null,
+        defaultValue: () -> T
+    ): ReadOnlyProperty<Any?, KottageStore<T>>
+
+    fun <T : Any> nullableProperty(
+        type: KType,
+        key: String? = null,
+        expireTime: Duration? = null
+    ): ReadOnlyProperty<Any?, KottageStore<T?>>
+
     suspend fun getDebugStatus(): String
 }
 
@@ -152,4 +167,19 @@ suspend inline fun <reified T : Any> KottageStorage.getEntry(key: String): Kotta
 @Throws(CancellationException::class)
 suspend inline fun <reified T : Any> KottageStorage.getEntryOrNull(key: String): KottageEntry<T>? {
     return getEntryOrNull(key, typeOf<T>())
+}
+
+inline fun <reified T : Any> KottageStorage.property(
+    key: String? = null,
+    expireTime: Duration? = null,
+    noinline defaultValue: () -> T
+): ReadOnlyProperty<Any?, KottageStore<T>> {
+    return property(typeOf<T>(), key, expireTime, defaultValue)
+}
+
+inline fun <reified T : Any> KottageStorage.nullableProperty(
+    key: String? = null,
+    expireTime: Duration? = null
+): ReadOnlyProperty<Any?, KottageStore<T?>> {
+    return nullableProperty(typeOf<T>(), key, expireTime)
 }

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/property/KottageStorageStore.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/property/KottageStorageStore.kt
@@ -1,0 +1,34 @@
+package io.github.irgaly.kottage.internal.property
+
+import io.github.irgaly.kottage.KottageStorage
+import io.github.irgaly.kottage.property.KottageStore
+import kotlin.reflect.KType
+import kotlin.time.Duration
+
+internal class KottageStorageStore<T> (
+    private val storage: KottageStorage,
+    private val key: String,
+    private val type: KType,
+    private val expireTime: Duration?,
+    private val defaultValue: () -> T
+): KottageStore<T> {
+    override suspend fun read(): T {
+        return storage.getOrNull(key, type) ?: defaultValue()
+    }
+
+    override suspend fun write(value: T) {
+        if (value == null) {
+            storage.remove(key)
+        } else {
+            storage.put(key, value, type, expireTime = expireTime)
+        }
+    }
+
+    override suspend fun exists(): Boolean {
+        return (storage.exists(key) || (defaultValue() != null))
+    }
+
+    override suspend fun clear() {
+        storage.remove(key)
+    }
+}

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/property/KottageStore.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/property/KottageStore.kt
@@ -1,0 +1,8 @@
+package io.github.irgaly.kottage.property
+
+interface KottageStore<T> {
+    suspend fun read(): T
+    suspend fun write(value: T)
+    suspend fun exists(): Boolean
+    suspend fun clear()
+}


### PR DESCRIPTION
#28 の対応

`by storage.property()` で使えるようにする