### PR TITLE
Fix: kotlinx coroutines/serialization to api dependency

### DIFF
--- a/kottage/build.gradle.kts
+++ b/kottage/build.gradle.kts
@@ -19,6 +19,8 @@ kotlin {
         binaries.framework {
             baseName = "Kottage"
             xcf.add(this)
+            export(libs.kotlinx.coroutines.core)
+            export(libs.kotlinx.serialization)
         }
     }
     ios(configure = configureXcf)
@@ -40,8 +42,8 @@ kotlin {
         commonMain {
             dependencies {
                 implementation(projects.kottage.core)
-                implementation(libs.kotlinx.coroutines.core)
-                implementation(libs.kotlinx.serialization)
+                api(libs.kotlinx.coroutines.core)
+                api(libs.kotlinx.serialization)
             }
         }
         commonTest {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,8 +7,8 @@ pluginManagement {
         gradlePluginPortal()
     }
     plugins {
-        id("com.android.application") version "8.0.0-alpha02"
-        id("com.android.library") version "8.0.0-alpha02"
+        id("com.android.application") version "8.0.0-alpha04"
+        id("com.android.library") version "8.0.0-alpha04"
         id("io.kotest.multiplatform") version "5.5.1"
         kotlin("android") version "1.7.10"
         kotlin("multiplatform") version "1.7.10"


### PR DESCRIPTION
coroutines core, serialization を api() 依存にする。

Kottage ライブラリを読み込んだ場合にはこの二つは利用者としても必須なので api で露出させたほうがいい。

* make coroutines, serialization to public
* update AGP 8.0.0-alpha04