### PR TITLE
fix: Page hasNext, hasPrevious

### DIFF
--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/KottageListPage.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/KottageListPage.kt
@@ -4,9 +4,15 @@ package io.github.irgaly.kottage
 data class KottageListPage(
     val items: List<KottageListEntry>,
     val previousPositionId: String?,
-    val nextPositionId: String?
+    val nextPositionId: String?,
+    /**
+     * has previous page
+     */
+    val hasPrevious: Boolean,
+    /**
+     * has next page
+     */
+    val hasNext: Boolean
 ) {
     val isEmpty: Boolean get() = items.isEmpty()
-    val hasPrevious: Boolean get() = (previousPositionId != null)
-    val hasNext: Boolean get() = (nextPositionId != null)
 }

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageListOperator.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageListOperator.kt
@@ -103,7 +103,7 @@ internal class KottageListOperator(
      *
      * positionId からたどり、有効な Entry があればそれを返す
      */
-    fun getAvailableListItem(
+    fun getAvailableListEntry(
         positionId: String,
         direction: KottageListDirection
     ): ItemListEntry? {

--- a/kottage/src/commonTest/kotlin/io/github/irgaly/kottage/KottageListTest.kt
+++ b/kottage/src/commonTest/kotlin/io/github/irgaly/kottage/KottageListTest.kt
@@ -143,6 +143,23 @@ class KottageListTest : DescribeSpec({
                 lastPage.hasNext shouldBe false
                 lastPage.items[0].itemKey shouldBe "key5"
             }
+            it("Page: hasPrevious, hasNext の要素有無判定") {
+                val storage = kottage().first.storage("hasprevious_hasnext")
+                val list = storage.list("list_hasprevious_hasnext")
+                list.addAll(
+                    listOf(
+                        kottageListValue("key1", "value1"),
+                        kottageListValue("key2", "value2"),
+                        kottageListValue("key3", "value3")
+                    )
+                )
+                list.remove(checkNotNull(list.getFirst()).positionId)
+                list.remove(checkNotNull(list.getLast()).positionId)
+                val entry2 = checkNotNull(list.getFirst())
+                val page = list.getPageFrom(entry2.positionId, 1)
+                page.hasPrevious shouldBe false
+                page.hasNext shouldBe false
+            }
             it("MetaData の読み書き") {
                 val cache = kottage().first.cache("metadata")
                 val list = cache.list("list_metadata")

--- a/kottage/src/commonTest/kotlin/io/github/irgaly/kottage/KottageListTest.kt
+++ b/kottage/src/commonTest/kotlin/io/github/irgaly/kottage/KottageListTest.kt
@@ -150,15 +150,19 @@ class KottageListTest : DescribeSpec({
                     listOf(
                         kottageListValue("key1", "value1"),
                         kottageListValue("key2", "value2"),
-                        kottageListValue("key3", "value3")
+                        kottageListValue("key3", "value3"),
+                        kottageListValue("key4", "value4")
                     )
                 )
                 list.remove(checkNotNull(list.getFirst()).positionId)
                 list.remove(checkNotNull(list.getLast()).positionId)
                 val entry2 = checkNotNull(list.getFirst())
-                val page = list.getPageFrom(entry2.positionId, 1)
-                page.hasPrevious shouldBe false
-                page.hasNext shouldBe false
+                val page1 = list.getPageFrom(entry2.positionId, 1)
+                val page2 = list.getPageFrom(page1.nextPositionId, 1)
+                page1.hasPrevious shouldBe false
+                page1.hasNext shouldBe true
+                page2.hasPrevious shouldBe true
+                page2.hasNext shouldBe false
             }
             it("MetaData の読み書き") {
                 val cache = kottage().first.cache("metadata")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,8 +7,8 @@ pluginManagement {
         gradlePluginPortal()
     }
     plugins {
-        id("com.android.application") version "8.0.0-alpha04"
-        id("com.android.library") version "8.0.0-alpha04"
+        id("com.android.application") version "8.0.0-alpha05"
+        id("com.android.library") version "8.0.0-alpha05"
         id("io.kotest.multiplatform") version "5.5.1"
         kotlin("android") version "1.7.10"
         kotlin("multiplatform") version "1.7.10"


### PR DESCRIPTION
#44 の対応

* Page hasNext, hasPrevious はその先に有効なアイテムがあるかどうかを読み取って判定する

有効なアイテムかどうかのチェックがないと、hasNext = true なのに実際には次のPageが空で取得されたりする。