### PR TITLE
implement JS browser by indexddb

### DIFF
--- a/.github/karma.config.d/karma.conf.js
+++ b/.github/karma.config.d/karma.conf.js
@@ -1,0 +1,4 @@
+config.plugins.push('karma-safarinative-launcher');
+config.browsers.push('SafariNative');
+// ↓ only Safari
+//config.browsers = ['SafariNative'];

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -53,6 +53,12 @@ jobs:
       - name: Native macOS X64 Test
         run: |
           ./gradlew macosX64Test
+      - name: JS Browser Test Build
+        run: |
+          ./gradlew jsTestClasses
+      - name: JS Browser Test
+        run: |
+          ./gradlew jsTest
       - uses: EnricoMi/publish-unit-test-result-action/composite@v2
         if: always()
         with:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ sqldelight-driver-android = { module = "com.squareup.sqldelight:android-driver",
 sqldelight-driver-jvm = { module = "com.squareup.sqldelight:sqlite-driver", version.ref = "sqldelight" }
 sqldelight-driver-native = { module = "com.squareup.sqldelight:native-driver", version.ref = "sqldelight" }
 sqldelight-driver-js = { module = "com.squareup.sqldelight:sqljs-driver", version.ref = "sqldelight" }
+indexeddb = { module = "com.juul.indexeddb:core", version = "0.3.0" }
 klock = { module = "com.soywiz.korlibs.klock:klock", version = "3.2.0" }
 kodein-di = { module = "org.kodein.di:kodein-di", version = "7.15.0" }
 

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -52,10 +52,45 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@leichtgewicht/ip-codec@^2.0.1":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
+  integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
+
+"@types/body-parser@*":
+  version "1.19.2"
+  resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.19.2.tgz#aea2059e28b7658639081347ac4fab3de166e6f0"
+  integrity sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==
+  dependencies:
+    "@types/connect" "*"
+    "@types/node" "*"
+
+"@types/bonjour@^3.5.9":
+  version "3.5.10"
+  resolved "https://registry.yarnpkg.com/@types/bonjour/-/bonjour-3.5.10.tgz#0f6aadfe00ea414edc86f5d106357cda9701e275"
+  integrity sha512-p7ienRMiS41Nu2/igbJxxLDWrSZ0WxM8UQgCeO9KhoVF7cOVFkrKsiDr1EsJIla8vV3oEEjGcz11jc5yimhzZw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/component-emitter@^1.2.10":
   version "1.2.11"
   resolved "https://registry.yarnpkg.com/@types/component-emitter/-/component-emitter-1.2.11.tgz#50d47d42b347253817a39709fef03ce66a108506"
   integrity sha512-SRXjM+tfsSlA9VuG8hGO2nft2p8zjXCK1VcC6N4NXbBbYbSia9kzCChYQajIjzIqOOOuh5Ock6MmV2oux4jDZQ==
+
+"@types/connect-history-api-fallback@^1.3.5":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.3.5.tgz#d1f7a8a09d0ed5a57aee5ae9c18ab9b803205dae"
+  integrity sha512-h8QJa8xSb1WD4fpKBDcATDNGXghFj6/3GRWG6dhmRcu0RX1Ubasur2Uvx5aeEwlf0MwblEC2bMzzMQntxnw/Cw==
+  dependencies:
+    "@types/express-serve-static-core" "*"
+    "@types/node" "*"
+
+"@types/connect@*":
+  version "3.4.35"
+  resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.35.tgz#5fcf6ae445e4021d1fc2219a4873cc73a3bb2ad1"
+  integrity sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==
+  dependencies:
+    "@types/node" "*"
 
 "@types/cookie@^0.4.1":
   version "0.4.1"
@@ -93,15 +128,90 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.51.tgz#cfd70924a25a3fd32b218e5e420e6897e1ac4f40"
   integrity sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==
 
-"@types/json-schema@*", "@types/json-schema@^7.0.8":
+"@types/express-serve-static-core@*", "@types/express-serve-static-core@^4.17.18":
+  version "4.17.31"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz#a1139efeab4e7323834bb0226e62ac019f474b2f"
+  integrity sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==
+  dependencies:
+    "@types/node" "*"
+    "@types/qs" "*"
+    "@types/range-parser" "*"
+
+"@types/express@*", "@types/express@^4.17.13":
+  version "4.17.14"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.14.tgz#143ea0557249bc1b3b54f15db4c81c3d4eb3569c"
+  integrity sha512-TEbt+vaPFQ+xpxFLFssxUDXj5cWCxZJjIcB7Yg0k0GMHGtgtQgpvx/MUQUeAkNbA9AAGrwkAsoeItdTgS7FMyg==
+  dependencies:
+    "@types/body-parser" "*"
+    "@types/express-serve-static-core" "^4.17.18"
+    "@types/qs" "*"
+    "@types/serve-static" "*"
+
+"@types/http-proxy@^1.17.8":
+  version "1.17.9"
+  resolved "https://registry.yarnpkg.com/@types/http-proxy/-/http-proxy-1.17.9.tgz#7f0e7931343761efde1e2bf48c40f02f3f75705a"
+  integrity sha512-QsbSjA/fSk7xB+UXlCT3wHBy5ai9wOcNDWwZAtud+jXhwOM3l+EYZh8Lng4+/6n8uar0J7xILzqftJdJ/Wdfkw==
+  dependencies:
+    "@types/node" "*"
+
+"@types/json-schema@*", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
+
+"@types/mime@*":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.1.tgz#5f8f2bca0a5863cb69bc0b0acd88c96cb1d4ae10"
+  integrity sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==
 
 "@types/node@*", "@types/node@>=10.0.0":
   version "18.6.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.6.3.tgz#4e4a95b6fe44014563ceb514b2598b3e623d1c98"
   integrity sha512-6qKpDtoaYLM+5+AFChLhHermMQxc3TOEFIDzrZLPRGHPrLEwqFkkT5Kx3ju05g6X7uDPazz3jHbKPX0KzCjntg==
+
+"@types/qs@*":
+  version "6.9.7"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
+  integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
+
+"@types/range-parser@*":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
+  integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
+
+"@types/retry@0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
+  integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
+
+"@types/serve-index@^1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@types/serve-index/-/serve-index-1.9.1.tgz#1b5e85370a192c01ec6cec4735cf2917337a6278"
+  integrity sha512-d/Hs3nWDxNL2xAczmOVZNj92YZCS6RGxfBPjKzuu/XirCgXdpKEb88dYNbrYGint6IVWLNP+yonwVAuRC0T2Dg==
+  dependencies:
+    "@types/express" "*"
+
+"@types/serve-static@*", "@types/serve-static@^1.13.10":
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.15.0.tgz#c7930ff61afb334e121a9da780aac0d9b8f34155"
+  integrity sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==
+  dependencies:
+    "@types/mime" "*"
+    "@types/node" "*"
+
+"@types/sockjs@^0.3.33":
+  version "0.3.33"
+  resolved "https://registry.yarnpkg.com/@types/sockjs/-/sockjs-0.3.33.tgz#570d3a0b99ac995360e3136fd6045113b1bd236f"
+  integrity sha512-f0KEEe05NvUnat+boPTZ0dgaLZ4SfSouXUgv5noUiefG2ajgKjmETo9ZJyuqsl7dfl2aHlLJUiki6B4ZYldiiw==
+  dependencies:
+    "@types/node" "*"
+
+"@types/ws@^8.5.1":
+  version "8.5.3"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.3.tgz#7d25a1ffbecd3c4f2d35068d0b283c037003274d"
+  integrity sha512-6YOoWjruKj1uLf3INHH7D3qTXwFfEsg1kf3c0uDdSBJwfa/llkwIjrAGV7j7mVgGNbzTQ3HiHKKDXl6bJPD97w==
+  dependencies:
+    "@types/node" "*"
 
 "@ungap/promise-all-settled@1.1.2":
   version "1.1.2"
@@ -261,7 +371,7 @@ abab@^2.0.6:
   resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
   integrity sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==
 
-accepts@~1.3.4:
+accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
   integrity sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==
@@ -279,10 +389,24 @@ acorn@^8.4.1, acorn@^8.5.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.0.tgz#88c0187620435c7f6015803f5539dae05a9dbea8"
   integrity sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==
 
+ajv-formats@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.1.tgz#6e669400659eb74973bbf2e33327180a0996b520"
+  integrity sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==
+  dependencies:
+    ajv "^8.0.0"
+
 ajv-keywords@^3.5.2:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
   integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
+
+ajv-keywords@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-5.1.0.tgz#69d4d385a4733cdbeab44964a1170a88f87f0e16"
+  integrity sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==
+  dependencies:
+    fast-deep-equal "^3.1.3"
 
 ajv@^6.12.5:
   version "6.12.6"
@@ -294,10 +418,25 @@ ajv@^6.12.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+ajv@^8.0.0, ajv@^8.8.0:
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
+  integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
 ansi-colors@4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
   integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
+
+ansi-html-community@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/ansi-html-community/-/ansi-html-community-0.0.8.tgz#69fbc4d6ccbe383f9736934ae34c3f8290f1bf41"
+  integrity sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==
 
 ansi-regex@^5.0.1:
   version "5.0.1"
@@ -324,6 +463,16 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
+array-flatten@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
+  integrity sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==
+
+array-flatten@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-2.1.2.tgz#24ef80a28c1a893617e2149b0c6d0d788293b099"
+  integrity sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -334,10 +483,33 @@ base64id@2.0.0, base64id@~2.0.0:
   resolved "https://registry.yarnpkg.com/base64id/-/base64id-2.0.0.tgz#2770ac6bc47d312af97a8bf9a634342e0cd25cb6"
   integrity sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==
 
+batch@0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
+  integrity sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==
+
 binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
+
+body-parser@1.20.1:
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.1.tgz#b1812a8912c195cd371a3ee5e66faa2338a5c668"
+  integrity sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==
+  dependencies:
+    bytes "3.1.2"
+    content-type "~1.0.4"
+    debug "2.6.9"
+    depd "2.0.0"
+    destroy "1.2.0"
+    http-errors "2.0.0"
+    iconv-lite "0.4.24"
+    on-finished "2.4.1"
+    qs "6.11.0"
+    raw-body "2.5.1"
+    type-is "~1.6.18"
+    unpipe "1.0.0"
 
 body-parser@^1.19.0:
   version "1.20.0"
@@ -356,6 +528,16 @@ body-parser@^1.19.0:
     raw-body "2.5.1"
     type-is "~1.6.18"
     unpipe "1.0.0"
+
+bonjour-service@^1.0.11:
+  version "1.0.14"
+  resolved "https://registry.yarnpkg.com/bonjour-service/-/bonjour-service-1.0.14.tgz#c346f5bc84e87802d08f8d5a60b93f758e514ee7"
+  integrity sha512-HIMbgLnk1Vqvs6B4Wq5ep7mxvj9sGz5d1JJyDNSGNIdA/w2MCz6GTjWTdjqOJV1bEPj+6IkxDvWNFKEBxNt4kQ==
+  dependencies:
+    array-flatten "^2.1.2"
+    dns-equal "^1.0.0"
+    fast-deep-equal "^3.1.3"
+    multicast-dns "^7.2.5"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -399,6 +581,11 @@ buffer-from@^1.0.0:
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
 
+bytes@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
+  integrity sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==
+
 bytes@3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.2.tgz#8b0beeb98605adf1b128fa4386403c009e0221a5"
@@ -430,7 +617,7 @@ chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chokidar@3.5.3, chokidar@^3.5.1:
+chokidar@3.5.3, chokidar@^3.5.1, chokidar@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
   integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
@@ -480,7 +667,7 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-colorette@^2.0.14:
+colorette@^2.0.10, colorette@^2.0.14:
   version "2.0.19"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.19.tgz#cdf044f47ad41a0f4b56b3a0d5b4e6e1a2d5a798"
   integrity sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==
@@ -500,10 +687,35 @@ component-emitter@~1.3.0:
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
 
+compressible@~2.0.16:
+  version "2.0.18"
+  resolved "https://registry.yarnpkg.com/compressible/-/compressible-2.0.18.tgz#af53cca6b070d4c3c0750fbd77286a6d7cc46fba"
+  integrity sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==
+  dependencies:
+    mime-db ">= 1.43.0 < 2"
+
+compression@^1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/compression/-/compression-1.7.4.tgz#95523eff170ca57c29a0ca41e6fe131f41e5bb8f"
+  integrity sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==
+  dependencies:
+    accepts "~1.3.5"
+    bytes "3.0.0"
+    compressible "~2.0.16"
+    debug "2.6.9"
+    on-headers "~1.0.2"
+    safe-buffer "5.1.2"
+    vary "~1.1.2"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
+
+connect-history-api-fallback@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz#8b32089359308d111115d81cad3fceab888f97bc"
+  integrity sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==
 
 connect@^3.7.0:
   version "3.7.0"
@@ -515,15 +727,37 @@ connect@^3.7.0:
     parseurl "~1.3.3"
     utils-merge "1.0.1"
 
+content-disposition@0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.4.tgz#8b82b4efac82512a02bb0b1dcec9d2c5e8eb5bfe"
+  integrity sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==
+  dependencies:
+    safe-buffer "5.2.1"
+
 content-type@~1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
+cookie-signature@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
+  integrity sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==
+
+cookie@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
+  integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
+
 cookie@~0.4.1:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.2.tgz#0e41f24de5ecf317947c82fc789e06a884824432"
   integrity sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==
+
+core-util-is@~1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
+  integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
 cors@~2.8.5:
   version "2.8.5"
@@ -559,7 +793,7 @@ debug@2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4.3.4, debug@^4.3.4, debug@~4.3.1, debug@~4.3.2:
+debug@4.3.4, debug@^4.1.0, debug@^4.3.4, debug@~4.3.1, debug@~4.3.2:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -571,15 +805,37 @@ decamelize@^4.0.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
   integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
 
+default-gateway@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/default-gateway/-/default-gateway-6.0.3.tgz#819494c888053bdb743edbf343d6cdf7f2943a71"
+  integrity sha512-fwSOJsbbNzZ/CUFpqFBqYfYNLj1NbMPm8MMCIzHjC83iSJRBEGmDUxU+WP661BaBQImeC2yHwXtz+P/O9o+XEg==
+  dependencies:
+    execa "^5.0.0"
+
+define-lazy-prop@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
+  integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
+
 depd@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
   integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
+depd@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
+  integrity sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==
+
 destroy@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
+
+detect-node@^2.0.4:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
+  integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
 
 di@^0.0.1:
   version "0.0.1"
@@ -591,6 +847,18 @@ diff@5.0.0:
   resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
   integrity sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==
 
+dns-equal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/dns-equal/-/dns-equal-1.0.0.tgz#b39e7f1da6eb0a75ba9c17324b34753c47e0654d"
+  integrity sha512-z+paD6YUQsk+AbGCEM4PrOXSss5gd66QfcVBFTKR/HpFL9jCqikS94HYwKww6fQyO7IxrIIyUu+g0Ka9tUS2Cg==
+
+dns-packet@^5.2.2:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/dns-packet/-/dns-packet-5.4.0.tgz#1f88477cf9f27e78a213fb6d118ae38e759a879b"
+  integrity sha512-EgqGeaBB8hLiHLZtp/IbaDQTL8pZ0+IvwzSHA6d7VyMDM+B9hgddEMa9xjK5oYnw0ci0JQ6g2XCD7/f6cafU6g==
+  dependencies:
+    "@leichtgewicht/ip-codec" "^2.0.1"
+
 dom-serialize@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/dom-serialize/-/dom-serialize-2.2.1.tgz#562ae8999f44be5ea3076f5419dcd59eb43ac95b"
@@ -600,6 +868,14 @@ dom-serialize@^2.2.1:
     ent "~2.2.0"
     extend "^3.0.0"
     void-elements "^2.0.0"
+
+dukat@0.5.8-rc.4:
+  version "0.5.8-rc.4"
+  resolved "https://registry.yarnpkg.com/dukat/-/dukat-0.5.8-rc.4.tgz#90384dcb50b14c26f0e99dae92b2dea44f5fce21"
+  integrity sha512-ZnMt6DGBjlVgK2uQamXfd7uP/AxH7RqI0BL9GLrrJb2gKdDxvJChWy+M9AQEaL+7/6TmxzJxFOsRiInY9oGWTA==
+  dependencies:
+    google-protobuf "3.12.2"
+    typescript "3.9.5"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -705,6 +981,11 @@ estraverse@^5.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
+etag@~1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
+  integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
+
 eventemitter3@^4.0.0:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
@@ -715,12 +996,64 @@ events@^3.2.0:
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
+execa@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-5.1.1.tgz#f80ad9cbf4298f7bd1d4c9555c21e93741c411dd"
+  integrity sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==
+  dependencies:
+    cross-spawn "^7.0.3"
+    get-stream "^6.0.0"
+    human-signals "^2.1.0"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^4.0.1"
+    onetime "^5.1.2"
+    signal-exit "^3.0.3"
+    strip-final-newline "^2.0.0"
+
+express@^4.17.3:
+  version "4.18.2"
+  resolved "https://registry.yarnpkg.com/express/-/express-4.18.2.tgz#3fabe08296e930c796c19e3c516979386ba9fd59"
+  integrity sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==
+  dependencies:
+    accepts "~1.3.8"
+    array-flatten "1.1.1"
+    body-parser "1.20.1"
+    content-disposition "0.5.4"
+    content-type "~1.0.4"
+    cookie "0.5.0"
+    cookie-signature "1.0.6"
+    debug "2.6.9"
+    depd "2.0.0"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    finalhandler "1.2.0"
+    fresh "0.5.2"
+    http-errors "2.0.0"
+    merge-descriptors "1.0.1"
+    methods "~1.1.2"
+    on-finished "2.4.1"
+    parseurl "~1.3.3"
+    path-to-regexp "0.1.7"
+    proxy-addr "~2.0.7"
+    qs "6.11.0"
+    range-parser "~1.2.1"
+    safe-buffer "5.2.1"
+    send "0.18.0"
+    serve-static "1.15.0"
+    setprototypeof "1.2.0"
+    statuses "2.0.1"
+    type-is "~1.6.18"
+    utils-merge "1.0.1"
+    vary "~1.1.2"
+
 extend@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
-fast-deep-equal@^3.1.1:
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -734,6 +1067,13 @@ fastest-levenshtein@^1.0.12:
   version "1.0.14"
   resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.14.tgz#9054384e4b7a78c88d01a4432dc18871af0ac859"
   integrity sha512-tFfWHjnuUfKE186Tfgr+jtaFc0mZTApEgKDOeyN+FwOqRkO/zK/3h1AiRd8u8CY53owL3CUmGr/oI9p/RdyLTA==
+
+faye-websocket@^0.11.3:
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.11.4.tgz#7f0d9275cfdd86a1c963dc8b65fcc451edcbb1da"
+  integrity sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==
+  dependencies:
+    websocket-driver ">=0.5.1"
 
 fill-range@^7.0.1:
   version "7.0.1"
@@ -753,6 +1093,19 @@ finalhandler@1.1.2:
     on-finished "~2.3.0"
     parseurl "~1.3.3"
     statuses "~1.5.0"
+    unpipe "~1.0.0"
+
+finalhandler@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.2.0.tgz#7d23fe5731b207b4640e4fcd00aec1f9207a7b32"
+  integrity sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==
+  dependencies:
+    debug "2.6.9"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    on-finished "2.4.1"
+    parseurl "~1.3.3"
+    statuses "2.0.1"
     unpipe "~1.0.0"
 
 find-up@5.0.0:
@@ -791,6 +1144,16 @@ format-util@1.0.5:
   resolved "https://registry.yarnpkg.com/format-util/-/format-util-1.0.5.tgz#1ffb450c8a03e7bccffe40643180918cc297d271"
   integrity sha512-varLbTj0e0yVyRpqQhuWV+8hlePAgaoFRhNFj50BNjEIrw1/DphHSObtqwskVCPWNgzwPoQrZAbfa/SBiicNeg==
 
+forwarded@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
+  integrity sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==
+
+fresh@0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/fresh/-/fresh-0.5.2.tgz#3d8cadd90d976569fa835ab1f8e4b23a105605a7"
+  integrity sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==
+
 fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
@@ -799,6 +1162,11 @@ fs-extra@^8.1.0:
     graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
+
+fs-monkey@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/fs-monkey/-/fs-monkey-1.0.3.tgz#ae3ac92d53bb328efe0e9a1d9541f6ad8d48e2d3"
+  integrity sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q==
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -828,6 +1196,11 @@ get-intrinsic@^1.0.2:
     function-bind "^1.1.1"
     has "^1.0.3"
     has-symbols "^1.0.3"
+
+get-stream@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
+  integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
 glob-parent@~5.1.2:
   version "5.1.2"
@@ -865,10 +1238,20 @@ glob@^7.1.3, glob@^7.1.7:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+google-protobuf@3.12.2:
+  version "3.12.2"
+  resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.12.2.tgz#50ce9f9b6281235724eb243d6a83e969a2176e53"
+  integrity sha512-4CZhpuRr1d6HjlyrxoXoocoGFnRYgKULgMtikMddA9ztRyYR59Aondv2FioyxWVamRo0rF2XpYawkTCBEQOSkA==
+
 graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   version "4.2.10"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
+
+handle-thing@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.1.tgz#857f79ce359580c340d43081cc648970d0bb234e"
+  integrity sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==
 
 has-flag@^4.0.0:
   version "4.0.0"
@@ -892,6 +1275,26 @@ he@1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+hpack.js@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/hpack.js/-/hpack.js-2.1.6.tgz#87774c0949e513f42e84575b3c45681fade2a0b2"
+  integrity sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==
+  dependencies:
+    inherits "^2.0.1"
+    obuf "^1.0.0"
+    readable-stream "^2.0.1"
+    wbuf "^1.1.0"
+
+html-entities@^2.3.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-2.3.3.tgz#117d7626bece327fc8baace8868fa6f5ef856e46"
+  integrity sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==
+
+http-deceiver@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/http-deceiver/-/http-deceiver-1.2.7.tgz#fa7168944ab9a519d337cb0bec7284dc3e723d87"
+  integrity sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==
+
 http-errors@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-2.0.0.tgz#b7774a1486ef73cf7667ac9ae0858c012c57b9d3"
@@ -903,6 +1306,32 @@ http-errors@2.0.0:
     statuses "2.0.1"
     toidentifier "1.0.1"
 
+http-errors@~1.6.2:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
+  integrity sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.3"
+    setprototypeof "1.1.0"
+    statuses ">= 1.4.0 < 2"
+
+http-parser-js@>=0.5.1:
+  version "0.5.8"
+  resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.8.tgz#af23090d9ac4e24573de6f6aecc9d84a48bf20e3"
+  integrity sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q==
+
+http-proxy-middleware@^2.0.3:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz#e1a4dd6979572c7ab5a4e4b55095d1f32a74963f"
+  integrity sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==
+  dependencies:
+    "@types/http-proxy" "^1.17.8"
+    http-proxy "^1.18.1"
+    is-glob "^4.0.1"
+    is-plain-obj "^3.0.0"
+    micromatch "^4.0.2"
+
 http-proxy@^1.18.1:
   version "1.18.1"
   resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
@@ -911,6 +1340,11 @@ http-proxy@^1.18.1:
     eventemitter3 "^4.0.0"
     follow-redirects "^1.0.0"
     requires-port "^1.0.0"
+
+human-signals@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
+  integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
 iconv-lite@0.4.24:
   version "0.4.24"
@@ -942,15 +1376,30 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+
+inherits@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+  integrity sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==
 
 interpret@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
+
+ipaddr.js@1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
+  integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
+
+ipaddr.js@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-2.0.1.tgz#eca256a7a877e917aeb368b0a7497ddf42ef81c0"
+  integrity sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==
 
 is-binary-path@~2.1.0:
   version "2.1.0"
@@ -965,6 +1414,11 @@ is-core-module@^2.9.0:
   integrity sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==
   dependencies:
     has "^1.0.3"
+
+is-docker@^2.0.0, is-docker@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
+  integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
 
 is-extglob@^2.1.1:
   version "2.1.1"
@@ -993,6 +1447,11 @@ is-plain-obj@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
   integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
 
+is-plain-obj@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-3.0.0.tgz#af6f2ea14ac5a646183a5bbdb5baabbc156ad9d7"
+  integrity sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==
+
 is-plain-object@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
@@ -1000,10 +1459,27 @@ is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
+is-stream@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
+  integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
+
 is-unicode-supported@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
+
+is-wsl@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
+  integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
+  dependencies:
+    is-docker "^2.0.0"
+
+isarray@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
+  integrity sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==
 
 isbinaryfile@^4.0.8:
   version "4.0.10"
@@ -1046,6 +1522,11 @@ json-schema-traverse@^0.4.1:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
 
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
@@ -1066,6 +1547,11 @@ karma-mocha@2.0.1:
   integrity sha512-Tzd5HBjm8his2OA4bouAsATYEpZrp9vC7z5E5j4C5Of5Rrs1jY67RAwXNcVmd/Bnk1wgvQRou0zGVLey44G4tQ==
   dependencies:
     minimist "^1.2.3"
+
+karma-safarinative-launcher@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/karma-safarinative-launcher/-/karma-safarinative-launcher-1.1.0.tgz#9f3435e13365445051305eb4d1bb80757cf337a3"
+  integrity sha512-vdMjdQDHkSUbOZc8Zq2K5bBC0yJGFEgfrKRJTqt0Um0SC1Rt8drS2wcN6UA3h4LgsL3f1pMcmRSvKucbJE8Qdg==
 
 karma-sourcemap-loader@0.3.8:
   version "0.3.8"
@@ -1166,27 +1652,67 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==
 
+memfs@^3.4.3:
+  version "3.4.9"
+  resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.4.9.tgz#403bb953776d72fef4e39e1197a25ffa156d143a"
+  integrity sha512-3rm8kbrzpUGRyPKSGuk387NZOwQ90O4rI9tsWQkzNW7BLSnKGp23RsEsKK8N8QVCrtJoAMqy3spxHC4os4G6PQ==
+  dependencies:
+    fs-monkey "^1.0.3"
+
+merge-descriptors@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
+  integrity sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==
+
 merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-mime-db@1.52.0:
+methods@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
+  integrity sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==
+
+micromatch@^4.0.2:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
+  integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
+  dependencies:
+    braces "^3.0.2"
+    picomatch "^2.3.1"
+
+mime-db@1.52.0, "mime-db@>= 1.43.0 < 2":
   version "1.52.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@^2.1.27, mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.27, mime-types@^2.1.31, mime-types@~2.1.17, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
   dependencies:
     mime-db "1.52.0"
 
+mime@1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
+  integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
+
 mime@^2.5.2:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.6.0.tgz#a2a682a95cd4d0cb1d6257e28f83da7e35800367"
   integrity sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==
+
+mimic-fn@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
+  integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+
+minimalistic-assert@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz#2e194de044626d4a10e7f7fbc00ce73e83e4d5c7"
+  integrity sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==
 
 minimatch@5.0.1:
   version "5.0.1"
@@ -1257,6 +1783,14 @@ ms@2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
+multicast-dns@^7.2.5:
+  version "7.2.5"
+  resolved "https://registry.yarnpkg.com/multicast-dns/-/multicast-dns-7.2.5.tgz#77eb46057f4d7adbd16d9290fa7299f6fa64cced"
+  integrity sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==
+  dependencies:
+    dns-packet "^5.2.2"
+    thunky "^1.0.2"
+
 nanoid@3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
@@ -1272,6 +1806,11 @@ neo-async@^2.6.2:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
+node-forge@^1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
+  integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
+
 node-releases@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.6.tgz#8a7088c63a55e493845683ebf3c828d8c51c5503"
@@ -1282,6 +1821,13 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
+npm-run-path@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
+  integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
+  dependencies:
+    path-key "^3.0.0"
+
 object-assign@^4:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
@@ -1291,6 +1837,11 @@ object-inspect@^1.9.0:
   version "1.12.2"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.2.tgz#c0641f26394532f28ab8d796ab954e43c009a8ea"
   integrity sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==
+
+obuf@^1.0.0, obuf@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
+  integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
 
 on-finished@2.4.1:
   version "2.4.1"
@@ -1306,12 +1857,33 @@ on-finished@~2.3.0:
   dependencies:
     ee-first "1.1.1"
 
+on-headers@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.2.tgz#772b0ae6aaa525c399e489adfad90c403eb3c28f"
+  integrity sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==
+
 once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
   dependencies:
     wrappy "1"
+
+onetime@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
+  integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
+  dependencies:
+    mimic-fn "^2.1.0"
+
+open@^8.0.9:
+  version "8.4.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-8.4.0.tgz#345321ae18f8138f82565a910fdc6b39e8c244f8"
+  integrity sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==
+  dependencies:
+    define-lazy-prop "^2.0.0"
+    is-docker "^2.1.1"
+    is-wsl "^2.2.0"
 
 p-limit@^2.2.0:
   version "2.3.0"
@@ -1341,12 +1913,20 @@ p-locate@^5.0.0:
   dependencies:
     p-limit "^3.0.2"
 
+p-retry@^4.5.0:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.6.2.tgz#9baae7184057edd4e17231cee04264106e092a16"
+  integrity sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==
+  dependencies:
+    "@types/retry" "0.12.0"
+    retry "^0.13.1"
+
 p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-parseurl@~1.3.3:
+parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
@@ -1361,7 +1941,7 @@ path-is-absolute@^1.0.0:
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
   integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
 
-path-key@^3.1.0:
+path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
@@ -1371,12 +1951,17 @@ path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
+path-to-regexp@0.1.7:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
+  integrity sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==
+
 picocolors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
-picomatch@^2.0.4, picomatch@^2.2.1:
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -1387,6 +1972,19 @@ pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+process-nextick-args@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
+  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
+
+proxy-addr@~2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
+  integrity sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==
+  dependencies:
+    forwarded "0.2.0"
+    ipaddr.js "1.9.1"
 
 punycode@^2.1.0:
   version "2.1.1"
@@ -1405,6 +2003,13 @@ qs@6.10.3:
   dependencies:
     side-channel "^1.0.4"
 
+qs@6.11.0:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
+  integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
+  dependencies:
+    side-channel "^1.0.4"
+
 randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -1412,7 +2017,7 @@ randombytes@^2.1.0:
   dependencies:
     safe-buffer "^5.1.0"
 
-range-parser@^1.2.1:
+range-parser@^1.2.1, range-parser@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"
   integrity sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==
@@ -1426,6 +2031,28 @@ raw-body@2.5.1:
     http-errors "2.0.0"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
+
+readable-stream@^2.0.1:
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
+  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
+
+readable-stream@^3.0.6:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
 
 readdirp@~3.6.0:
   version "3.6.0"
@@ -1445,6 +2072,11 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
+
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
 requires-port@^1.0.0:
   version "1.0.0"
@@ -1472,6 +2104,11 @@ resolve@^1.9.0:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
+retry@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
+  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
+
 rfdc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.3.0.tgz#d0b7c441ab2720d05dc4cf26e01c89631d9da08b"
@@ -1484,7 +2121,12 @@ rimraf@^3.0.0, rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
-safe-buffer@^5.1.0:
+safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
+  integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -1503,12 +2145,81 @@ schema-utils@^3.1.0, schema-utils@^3.1.1:
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
+schema-utils@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-4.0.0.tgz#60331e9e3ae78ec5d16353c467c34b3a0a1d3df7"
+  integrity sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==
+  dependencies:
+    "@types/json-schema" "^7.0.9"
+    ajv "^8.8.0"
+    ajv-formats "^2.1.1"
+    ajv-keywords "^5.0.0"
+
+select-hose@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
+  integrity sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==
+
+selfsigned@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-2.1.1.tgz#18a7613d714c0cd3385c48af0075abf3f266af61"
+  integrity sha512-GSL3aowiF7wa/WtSFwnUrludWFoNhftq8bUkH9pkzjpN2XSPOAYEgg6e0sS9s0rZwgJzJiQRPU18A6clnoW5wQ==
+  dependencies:
+    node-forge "^1"
+
+send@0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/send/-/send-0.18.0.tgz#670167cc654b05f5aa4a767f9113bb371bc706be"
+  integrity sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==
+  dependencies:
+    debug "2.6.9"
+    depd "2.0.0"
+    destroy "1.2.0"
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    etag "~1.8.1"
+    fresh "0.5.2"
+    http-errors "2.0.0"
+    mime "1.6.0"
+    ms "2.1.3"
+    on-finished "2.4.1"
+    range-parser "~1.2.1"
+    statuses "2.0.1"
+
 serialize-javascript@6.0.0, serialize-javascript@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.0.tgz#efae5d88f45d7924141da8b5c3a7a7e663fefeb8"
   integrity sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==
   dependencies:
     randombytes "^2.1.0"
+
+serve-index@^1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/serve-index/-/serve-index-1.9.1.tgz#d3768d69b1e7d82e5ce050fff5b453bea12a9239"
+  integrity sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==
+  dependencies:
+    accepts "~1.3.4"
+    batch "0.6.1"
+    debug "2.6.9"
+    escape-html "~1.0.3"
+    http-errors "~1.6.2"
+    mime-types "~2.1.17"
+    parseurl "~1.3.2"
+
+serve-static@1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/serve-static/-/serve-static-1.15.0.tgz#faaef08cffe0a1a62f60cad0c4e513cff0ac9540"
+  integrity sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==
+  dependencies:
+    encodeurl "~1.0.2"
+    escape-html "~1.0.3"
+    parseurl "~1.3.3"
+    send "0.18.0"
+
+setprototypeof@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.1.0.tgz#d0bd85536887b6fe7c0d818cb962d9d91c54e656"
+  integrity sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==
 
 setprototypeof@1.2.0:
   version "1.2.0"
@@ -1543,6 +2254,11 @@ side-channel@^1.0.4:
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
 
+signal-exit@^3.0.3:
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
+  integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
+
 socket.io-adapter@~2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-2.4.0.tgz#b50a4a9ecdd00c34d4c8c808224daa1a786152a6"
@@ -1568,6 +2284,15 @@ socket.io@^4.4.1:
     engine.io "~6.2.0"
     socket.io-adapter "~2.4.0"
     socket.io-parser "~4.0.4"
+
+sockjs@^0.3.24:
+  version "0.3.24"
+  resolved "https://registry.yarnpkg.com/sockjs/-/sockjs-0.3.24.tgz#c9bc8995f33a111bea0395ec30aa3206bdb5ccce"
+  integrity sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==
+  dependencies:
+    faye-websocket "^0.11.3"
+    uuid "^8.3.2"
+    websocket-driver "^0.7.4"
 
 source-map-js@^1.0.2:
   version "1.0.2"
@@ -1596,12 +2321,35 @@ source-map@^0.6.0, source-map@^0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
+spdy-transport@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/spdy-transport/-/spdy-transport-3.0.0.tgz#00d4863a6400ad75df93361a1608605e5dcdcf31"
+  integrity sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==
+  dependencies:
+    debug "^4.1.0"
+    detect-node "^2.0.4"
+    hpack.js "^2.1.6"
+    obuf "^1.1.2"
+    readable-stream "^3.0.6"
+    wbuf "^1.7.3"
+
+spdy@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/spdy/-/spdy-4.0.2.tgz#b74f466203a3eda452c02492b91fb9e84a27677b"
+  integrity sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==
+  dependencies:
+    debug "^4.1.0"
+    handle-thing "^2.0.0"
+    http-deceiver "^1.2.7"
+    select-hose "^2.0.0"
+    spdy-transport "^3.0.0"
+
 statuses@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
 
-statuses@~1.5.0:
+"statuses@>= 1.4.0 < 2", statuses@~1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==
@@ -1624,12 +2372,31 @@ string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
+
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+  dependencies:
+    safe-buffer "~5.1.0"
+
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
+
+strip-final-newline@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
+  integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
 strip-json-comments@3.1.1:
   version "3.1.1"
@@ -1681,6 +2448,11 @@ terser@^5.7.2:
     commander "^2.20.0"
     source-map-support "~0.5.20"
 
+thunky@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
+  integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
+
 tmp@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
@@ -1707,6 +2479,11 @@ type-is@~1.6.18:
   dependencies:
     media-typer "0.3.0"
     mime-types "~2.1.24"
+
+typescript@3.9.5:
+  version "3.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
+  integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
 
 ua-parser-js@^0.7.30:
   version "0.7.31"
@@ -1738,12 +2515,22 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+util-deprecate@^1.0.1, util-deprecate@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
+
 utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-vary@^1:
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==
@@ -1760,6 +2547,13 @@ watchpack@^2.3.1:
   dependencies:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
+
+wbuf@^1.1.0, wbuf@^1.7.3:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/wbuf/-/wbuf-1.7.3.tgz#c1d8d149316d3ea852848895cb6a0bfe887b87df"
+  integrity sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==
+  dependencies:
+    minimalistic-assert "^1.0.0"
 
 webpack-cli@4.10.0:
   version "4.10.0"
@@ -1778,6 +2572,52 @@ webpack-cli@4.10.0:
     interpret "^2.2.0"
     rechoir "^0.7.0"
     webpack-merge "^5.7.3"
+
+webpack-dev-middleware@^5.3.1:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-5.3.3.tgz#efae67c2793908e7311f1d9b06f2a08dcc97e51f"
+  integrity sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==
+  dependencies:
+    colorette "^2.0.10"
+    memfs "^3.4.3"
+    mime-types "^2.1.31"
+    range-parser "^1.2.1"
+    schema-utils "^4.0.0"
+
+webpack-dev-server@4.9.2:
+  version "4.9.2"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.9.2.tgz#c188db28c7bff12f87deda2a5595679ebbc3c9bc"
+  integrity sha512-H95Ns95dP24ZsEzO6G9iT+PNw4Q7ltll1GfJHV4fKphuHWgKFzGHWi4alTlTnpk1SPPk41X+l2RB7rLfIhnB9Q==
+  dependencies:
+    "@types/bonjour" "^3.5.9"
+    "@types/connect-history-api-fallback" "^1.3.5"
+    "@types/express" "^4.17.13"
+    "@types/serve-index" "^1.9.1"
+    "@types/serve-static" "^1.13.10"
+    "@types/sockjs" "^0.3.33"
+    "@types/ws" "^8.5.1"
+    ansi-html-community "^0.0.8"
+    bonjour-service "^1.0.11"
+    chokidar "^3.5.3"
+    colorette "^2.0.10"
+    compression "^1.7.4"
+    connect-history-api-fallback "^1.6.0"
+    default-gateway "^6.0.3"
+    express "^4.17.3"
+    graceful-fs "^4.2.6"
+    html-entities "^2.3.2"
+    http-proxy-middleware "^2.0.3"
+    ipaddr.js "^2.0.1"
+    open "^8.0.9"
+    p-retry "^4.5.0"
+    rimraf "^3.0.2"
+    schema-utils "^4.0.0"
+    selfsigned "^2.0.1"
+    serve-index "^1.9.1"
+    sockjs "^0.3.24"
+    spdy "^4.0.2"
+    webpack-dev-middleware "^5.3.1"
+    ws "^8.4.2"
 
 webpack-merge@^4.1.5:
   version "4.2.2"
@@ -1829,6 +2669,20 @@ webpack@5.73.0:
     watchpack "^2.3.1"
     webpack-sources "^3.2.3"
 
+websocket-driver@>=0.5.1, websocket-driver@^0.7.4:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.4.tgz#89ad5295bbf64b480abcba31e4953aca706f5760"
+  integrity sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==
+  dependencies:
+    http-parser-js ">=0.5.1"
+    safe-buffer ">=5.1.0"
+    websocket-extensions ">=0.1.1"
+
+websocket-extensions@>=0.1.1:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
+  integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
+
 which@^1.2.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
@@ -1866,6 +2720,11 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
+ws@^8.4.2:
+  version "8.10.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.10.0.tgz#00a28c09dfb76eae4eb45c3b565f771d6951aa51"
+  integrity sha512-+s49uSmZpvtAsd2h37vIPy1RBusaLawVe8of+GyEPsaJTCMpj/2v8NpeK1SHXjBlQ95lQTmQofOJnFiLoaN3yw==
 
 ws@~8.2.3:
   version "8.2.3"

--- a/kottage/build.gradle.kts
+++ b/kottage/build.gradle.kts
@@ -30,14 +30,12 @@ kotlin {
     tvos(configure = configureXcf)
     tvosSimulatorArm64(configure = configureXcf)
     macosArm64(configure = configureXcf)
-    /*
     // JS
     js(IR) {
         browser()
         // nodejs has no indexeddb support
         //nodejs()
     }
-     */
     sourceSets {
         commonMain {
             dependencies {
@@ -58,14 +56,12 @@ kotlin {
                 implementation(projects.kottage.data.sqlite)
             }
         }
-        /*
         val commonIndexeddbMain by creating {
             dependsOn(commonMain.get())
             dependencies {
                 implementation(projects.kottage.data.indexeddb)
             }
         }
-         */
         val androidMain by getting {
             dependsOn(commonSqliteMain)
             dependencies {
@@ -76,13 +72,11 @@ kotlin {
             dependencies {
             }
         }
-        /*
         val jsMain by getting {
             dependsOn(commonIndexeddbMain)
             dependencies {
             }
         }
-         */
         val nativeMain by getting {
             dependsOn(commonSqliteMain)
             dependencies {

--- a/kottage/build.gradle.kts
+++ b/kottage/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.internal.os.OperatingSystem
 import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
@@ -32,7 +33,19 @@ kotlin {
     macosArm64(configure = configureXcf)
     // JS
     js(IR) {
-        browser()
+        browser {
+            if (
+                System.getenv().containsKey("GITHUB_ACTIONS")
+                && OperatingSystem.current().isMacOsX
+            ) {
+                testTask {
+                    useKarma {
+                        useChromeHeadless()
+                        useConfigDirectory(rootProject.file(".github/karma.config.d"))
+                    }
+                }
+            }
+        }
         // nodejs has no indexeddb support
         //nodejs()
     }
@@ -75,6 +88,13 @@ kotlin {
         val jsMain by getting {
             dependsOn(commonIndexeddbMain)
             dependencies {
+            }
+        }
+        val jsTest by getting {
+            dependencies {
+                // karma-safarinative-launcher だけが Safari を起動できる
+                // https://github.com/karma-runner/karma-safari-launcher/issues/29#issuecomment-870387251
+                implementation(devNpm("karma-safarinative-launcher", "1.1.0"))
             }
         }
         val nativeMain by getting {

--- a/kottage/core/build.gradle.kts
+++ b/kottage/core/build.gradle.kts
@@ -9,14 +9,12 @@ android {
 }
 
 kotlin {
-    /*
     // JS
     js(IR) {
         browser()
         // nodejs has no indexeddb support
         //nodejs()
     }
-     */
     sourceSets {
         commonMain {
             dependencies {

--- a/kottage/core/src/jsMain/kotlin/io/github/irgaly/kottage/platform/Files.kt
+++ b/kottage/core/src/jsMain/kotlin/io/github/irgaly/kottage/platform/Files.kt
@@ -3,11 +3,11 @@ package io.github.irgaly.kottage.platform
 actual class Files {
     actual companion object {
         actual fun exists(path: String): Boolean {
-            TODO()
+            throw UnsupportedOperationException("browser js cannot access to File Storage")
         }
 
         actual fun mkdirs(directoryPath: String): Boolean {
-            TODO()
+            throw UnsupportedOperationException("browser js cannot access to File Storage")
         }
 
         actual val separator: String = "/"

--- a/kottage/core/src/jsMain/kotlin/io/github/irgaly/kottage/platform/Id.kt
+++ b/kottage/core/src/jsMain/kotlin/io/github/irgaly/kottage/platform/Id.kt
@@ -1,12 +1,30 @@
 package io.github.irgaly.kottage.platform
 
+import kotlin.random.Random
+
+
 actual class Id {
     actual companion object {
+        private const val characters = "0123456789abcdef"
+        private val rand = Random.Default
+
         actual fun generateUuidV4(): String {
-            throw NotImplementedError()
+            // use pseudo UUID on JS
+            return "${generateRandomString(8)}-${generateRandomString(4)}-${generateRandomString(4)}-${
+                generateRandomString(4)
+            }-${generateRandomString(12)}"
         }
+
         actual fun generateUuidV4Short(): String {
-            throw NotImplementedError()
+            return generateRandomString(32)
+        }
+
+        private fun generateRandomString(length: Int): String {
+            val builder = StringBuilder()
+            (0 until length).forEach { _ ->
+                builder.append(characters[rand.nextInt(characters.length)])
+            }
+            return builder.toString()
         }
     }
 }

--- a/kottage/core/test/build.gradle.kts
+++ b/kottage/core/test/build.gradle.kts
@@ -3,11 +3,9 @@ plugins {
 }
 
 kotlin {
-    /*
     js(IR) {
         browser()
     }
-     */
     sourceSets {
         commonMain {
             dependencies {

--- a/kottage/core/test/src/jsMain/kotlin/io/github/irgaly/test/platform/Files.kt
+++ b/kottage/core/test/src/jsMain/kotlin/io/github/irgaly/test/platform/Files.kt
@@ -3,11 +3,11 @@ package io.github.irgaly.test.platform
 actual class Files {
     actual companion object {
         actual fun createTemporaryDirectory(): String {
-            throw NotImplementedError()
+            return "js-dummy-temporary-directory"
         }
 
         actual fun deleteRecursively(directoryPath: String): Boolean {
-            throw NotImplementedError()
+            return true
         }
     }
 }

--- a/kottage/data/indexeddb/build.gradle.kts
+++ b/kottage/data/indexeddb/build.gradle.kts
@@ -26,6 +26,7 @@ kotlin {
         }
         val jsMain by getting {
             dependencies {
+                api(libs.indexeddb)
             }
         }
     }

--- a/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/KottageIndexeddbDatabase.kt
+++ b/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/KottageIndexeddbDatabase.kt
@@ -14,7 +14,7 @@ class KottageIndexeddbDatabase(
 ) {
     companion object {
         suspend fun open(name: String): KottageIndexeddbDatabase {
-            val database = openDatabase(name, 2) { database, oldVersion, newVersion ->
+            val database = openDatabase(name, 3) { database, oldVersion, newVersion ->
                 with(ItemStoreSchema()) { migrate(database, oldVersion, newVersion) }
                 with(ItemEventStoreSchema()) { migrate(database, oldVersion, newVersion) }
                 with(ItemListStoreSchema()) { migrate(database, oldVersion, newVersion) }

--- a/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/KottageIndexeddbDatabase.kt
+++ b/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/KottageIndexeddbDatabase.kt
@@ -1,0 +1,28 @@
+package io.github.irgaly.kottage.data.indexeddb
+
+import com.juul.indexeddb.Database
+import com.juul.indexeddb.openDatabase
+import io.github.irgaly.kottage.data.indexeddb.schema.ItemEventStoreSchema
+import io.github.irgaly.kottage.data.indexeddb.schema.ItemListStatsStoreSchema
+import io.github.irgaly.kottage.data.indexeddb.schema.ItemListStoreSchema
+import io.github.irgaly.kottage.data.indexeddb.schema.ItemStatsStoreSchema
+import io.github.irgaly.kottage.data.indexeddb.schema.ItemStoreSchema
+import io.github.irgaly.kottage.data.indexeddb.schema.StatsStoreSchema
+
+class KottageIndexeddbDatabase(
+    val database: Database
+) {
+    companion object {
+        suspend fun open(name: String): KottageIndexeddbDatabase {
+            val database = openDatabase(name, 2) { database, oldVersion, newVersion ->
+                with(ItemStoreSchema()) { migrate(database, oldVersion, newVersion) }
+                with(ItemEventStoreSchema()) { migrate(database, oldVersion, newVersion) }
+                with(ItemListStoreSchema()) { migrate(database, oldVersion, newVersion) }
+                with(ItemListStatsStoreSchema()) { migrate(database, oldVersion, newVersion) }
+                with(ItemStatsStoreSchema()) { migrate(database, oldVersion, newVersion) }
+                with(StatsStoreSchema()) { migrate(database, oldVersion, newVersion) }
+            }
+            return KottageIndexeddbDatabase(database)
+        }
+    }
+}

--- a/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/extension/IndexeddbExtension.kt
+++ b/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/extension/IndexeddbExtension.kt
@@ -1,0 +1,9 @@
+package io.github.irgaly.kottage.data.indexeddb.extension
+
+import com.juul.indexeddb.Key
+import com.juul.indexeddb.Queryable
+import com.juul.indexeddb.Transaction
+
+suspend fun Transaction.exists(store: Queryable, query: Key? = null): Boolean {
+    return (0 < store.count(query))
+}

--- a/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/extension/Jso.kt
+++ b/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/extension/Jso.kt
@@ -1,0 +1,5 @@
+package io.github.irgaly.kottage.data.indexeddb.extension
+
+@Suppress("UnsafeCastFromDynamic")
+fun <T : Any> jso(): T = js("({})")
+inline fun <T : Any> jso(block: T.() -> Unit): T = jso<T>().apply(block)

--- a/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/ItemEventStoreSchema.kt
+++ b/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/ItemEventStoreSchema.kt
@@ -1,0 +1,23 @@
+package io.github.irgaly.kottage.data.indexeddb.schema
+
+import com.juul.indexeddb.Database
+import com.juul.indexeddb.KeyPath
+import com.juul.indexeddb.VersionChangeTransaction
+
+class ItemEventStoreSchema: StoreSchema {
+    override fun VersionChangeTransaction.migrate(database: Database, oldVersion: Int, newVersion: Int) {
+        val store = if (oldVersion < 2) {
+            database.createObjectStore("item_event", KeyPath("id"))
+        } else {
+            objectStore("item_event")
+        }
+        if (oldVersion < 2) {
+            store.createIndex("item_event_created_at", KeyPath("created_at"), false)
+            store.createIndex("item_event_expire_at", KeyPath("expire_at"), false)
+            store.createIndex("item_event_item_type_created_at", KeyPath("item_type", "created_at"), false)
+            store.createIndex("item_event_item_type_expire_at", KeyPath("item_type", "expire_at"), false)
+            store.createIndex("item_event_item_list_type_created_at", KeyPath("item_list_type", "created_at"), false)
+            store.createIndex("item_event_item_list_type_expire_at", KeyPath("item_list_type", "expire_at"), false)
+        }
+    }
+}

--- a/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/ItemEventStoreSchema.kt
+++ b/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/ItemEventStoreSchema.kt
@@ -6,18 +6,34 @@ import com.juul.indexeddb.VersionChangeTransaction
 
 class ItemEventStoreSchema: StoreSchema {
     override fun VersionChangeTransaction.migrate(database: Database, oldVersion: Int, newVersion: Int) {
-        val store = if (oldVersion < 2) {
+        val store = if (oldVersion < 3) {
             database.createObjectStore("item_event", KeyPath("id"))
         } else {
             objectStore("item_event")
         }
-        if (oldVersion < 2) {
+        if (oldVersion < 3) {
             store.createIndex("item_event_created_at", KeyPath("created_at"), false)
             store.createIndex("item_event_expire_at", KeyPath("expire_at"), false)
-            store.createIndex("item_event_item_type_created_at", KeyPath("item_type", "created_at"), false)
-            store.createIndex("item_event_item_type_expire_at", KeyPath("item_type", "expire_at"), false)
-            store.createIndex("item_event_item_list_type_created_at", KeyPath("item_list_type", "created_at"), false)
-            store.createIndex("item_event_item_list_type_expire_at", KeyPath("item_list_type", "expire_at"), false)
+            store.createIndex(
+                "item_event_item_type_created_at",
+                KeyPath("item_type", "created_at"),
+                false
+            )
+            store.createIndex(
+                "item_event_item_type_expire_at",
+                KeyPath("item_type", "expire_at"),
+                false
+            )
+            store.createIndex(
+                "item_event_item_list_type_created_at",
+                KeyPath("item_list_type", "created_at"),
+                false
+            )
+            store.createIndex(
+                "item_event_item_list_type_expire_at",
+                KeyPath("item_list_type", "expire_at"),
+                false
+            )
         }
     }
 }

--- a/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/ItemListStatsStoreSchema.kt
+++ b/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/ItemListStatsStoreSchema.kt
@@ -6,12 +6,12 @@ import com.juul.indexeddb.VersionChangeTransaction
 
 class ItemListStatsStoreSchema: StoreSchema {
     override fun VersionChangeTransaction.migrate(database: Database, oldVersion: Int, newVersion: Int) {
-        val store = if (oldVersion < 2) {
+        val store = if (oldVersion < 3) {
             database.createObjectStore("item_list_stats", KeyPath("item_list_type"))
         } else {
             objectStore("item_list_stats")
         }
-        if (oldVersion < 2) {
+        if (oldVersion < 3) {
             // no index
         }
     }

--- a/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/ItemListStatsStoreSchema.kt
+++ b/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/ItemListStatsStoreSchema.kt
@@ -1,0 +1,18 @@
+package io.github.irgaly.kottage.data.indexeddb.schema
+
+import com.juul.indexeddb.Database
+import com.juul.indexeddb.KeyPath
+import com.juul.indexeddb.VersionChangeTransaction
+
+class ItemListStatsStoreSchema: StoreSchema {
+    override fun VersionChangeTransaction.migrate(database: Database, oldVersion: Int, newVersion: Int) {
+        val store = if (oldVersion < 2) {
+            database.createObjectStore("item_list_stats", KeyPath("item_list_type"))
+        } else {
+            objectStore("item_list_stats")
+        }
+        if (oldVersion < 2) {
+            // no index
+        }
+    }
+}

--- a/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/ItemListStoreSchema.kt
+++ b/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/ItemListStoreSchema.kt
@@ -18,11 +18,7 @@ class ItemListStoreSchema: StoreSchema {
                 KeyPath("item_type", "item_key"),
                 false
             )
-            store.createIndex(
-                "item_list_type_item_type_expire_at",
-                KeyPath("type", "item_type", "expire_at"),
-                false
-            )
+            store.createIndex("item_list_type_expire_at", KeyPath("type", "expire_at"), false)
         }
     }
 }

--- a/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/ItemListStoreSchema.kt
+++ b/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/ItemListStoreSchema.kt
@@ -12,7 +12,7 @@ class ItemListStoreSchema: StoreSchema {
             objectStore("item_list")
         }
         if (oldVersion < 3) {
-            store.createIndex("item_list_item_type", KeyPath("item_type"), false)
+            store.createIndex("item_list_type", KeyPath("type"), false)
             store.createIndex(
                 "item_list_item_type_item_key",
                 KeyPath("item_type", "item_key"),

--- a/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/ItemListStoreSchema.kt
+++ b/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/ItemListStoreSchema.kt
@@ -1,0 +1,20 @@
+package io.github.irgaly.kottage.data.indexeddb.schema
+
+import com.juul.indexeddb.Database
+import com.juul.indexeddb.KeyPath
+import com.juul.indexeddb.VersionChangeTransaction
+
+class ItemListStoreSchema: StoreSchema {
+    override fun VersionChangeTransaction.migrate(database: Database, oldVersion: Int, newVersion: Int) {
+        val store = if (oldVersion < 2) {
+            database.createObjectStore("item_list", KeyPath("id"))
+        } else {
+            objectStore("item_list")
+        }
+        if (oldVersion < 2) {
+            store.createIndex("item_list_item_type", KeyPath("item_type"), false)
+            store.createIndex("item_list_item_type_item_key", KeyPath("item_type", "item_key"), false)
+            store.createIndex("item_list_type_item_type_expire_at", KeyPath("type", "item_type", "expire_at"), false)
+        }
+    }
+}

--- a/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/ItemListStoreSchema.kt
+++ b/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/ItemListStoreSchema.kt
@@ -6,15 +6,23 @@ import com.juul.indexeddb.VersionChangeTransaction
 
 class ItemListStoreSchema: StoreSchema {
     override fun VersionChangeTransaction.migrate(database: Database, oldVersion: Int, newVersion: Int) {
-        val store = if (oldVersion < 2) {
+        val store = if (oldVersion < 3) {
             database.createObjectStore("item_list", KeyPath("id"))
         } else {
             objectStore("item_list")
         }
-        if (oldVersion < 2) {
+        if (oldVersion < 3) {
             store.createIndex("item_list_item_type", KeyPath("item_type"), false)
-            store.createIndex("item_list_item_type_item_key", KeyPath("item_type", "item_key"), false)
-            store.createIndex("item_list_type_item_type_expire_at", KeyPath("type", "item_type", "expire_at"), false)
+            store.createIndex(
+                "item_list_item_type_item_key",
+                KeyPath("item_type", "item_key"),
+                false
+            )
+            store.createIndex(
+                "item_list_type_item_type_expire_at",
+                KeyPath("type", "item_type", "expire_at"),
+                false
+            )
         }
     }
 }

--- a/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/ItemStatsStoreSchema.kt
+++ b/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/ItemStatsStoreSchema.kt
@@ -6,12 +6,12 @@ import com.juul.indexeddb.VersionChangeTransaction
 
 class ItemStatsStoreSchema: StoreSchema {
     override fun VersionChangeTransaction.migrate(database: Database, oldVersion: Int, newVersion: Int) {
-        val store = if (oldVersion < 2) {
+        val store = if (oldVersion < 3) {
             database.createObjectStore("item_stats", KeyPath("item_type"))
         } else {
             objectStore("item_stats")
         }
-        if (oldVersion < 2) {
+        if (oldVersion < 3) {
             // no index
         }
     }

--- a/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/ItemStatsStoreSchema.kt
+++ b/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/ItemStatsStoreSchema.kt
@@ -1,0 +1,18 @@
+package io.github.irgaly.kottage.data.indexeddb.schema
+
+import com.juul.indexeddb.Database
+import com.juul.indexeddb.KeyPath
+import com.juul.indexeddb.VersionChangeTransaction
+
+class ItemStatsStoreSchema: StoreSchema {
+    override fun VersionChangeTransaction.migrate(database: Database, oldVersion: Int, newVersion: Int) {
+        val store = if (oldVersion < 2) {
+            database.createObjectStore("item_stats", KeyPath("item_type"))
+        } else {
+            objectStore("item_stats")
+        }
+        if (oldVersion < 2) {
+            // no index
+        }
+    }
+}

--- a/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/ItemStoreSchema.kt
+++ b/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/ItemStoreSchema.kt
@@ -1,0 +1,21 @@
+package io.github.irgaly.kottage.data.indexeddb.schema
+
+import com.juul.indexeddb.Database
+import com.juul.indexeddb.KeyPath
+import com.juul.indexeddb.VersionChangeTransaction
+
+class ItemStoreSchema: StoreSchema {
+    override fun VersionChangeTransaction.migrate(database: Database, oldVersion: Int, newVersion: Int) {
+        val store = if (oldVersion < 2) {
+            database.createObjectStore("item", KeyPath("key"))
+        } else {
+            objectStore("item")
+        }
+        if (oldVersion < 2) {
+            store.createIndex("item_type", KeyPath("type"), false)
+            store.createIndex("item_type_created_at", KeyPath("type", "created_at"), false)
+            store.createIndex("item_type_last_read_at", KeyPath("type", "last_read_at"), false)
+            store.createIndex("item_type_expire_at", KeyPath("type", "expire_at"), false)
+        }
+    }
+}

--- a/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/ItemStoreSchema.kt
+++ b/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/ItemStoreSchema.kt
@@ -6,16 +6,17 @@ import com.juul.indexeddb.VersionChangeTransaction
 
 class ItemStoreSchema: StoreSchema {
     override fun VersionChangeTransaction.migrate(database: Database, oldVersion: Int, newVersion: Int) {
-        val store = if (oldVersion < 2) {
+        val store = if (oldVersion < 3) {
             database.createObjectStore("item", KeyPath("key"))
         } else {
             objectStore("item")
         }
-        if (oldVersion < 2) {
+        if (oldVersion < 3) {
             store.createIndex("item_type", KeyPath("type"), false)
             store.createIndex("item_type_created_at", KeyPath("type", "created_at"), false)
             store.createIndex("item_type_last_read_at", KeyPath("type", "last_read_at"), false)
             store.createIndex("item_type_expire_at", KeyPath("type", "expire_at"), false)
+            store.createIndex("item_expire_at", KeyPath("expire_at"), false)
         }
     }
 }

--- a/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/StatsStoreSchema.kt
+++ b/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/StatsStoreSchema.kt
@@ -6,12 +6,12 @@ import com.juul.indexeddb.VersionChangeTransaction
 
 class StatsStoreSchema: StoreSchema {
     override fun VersionChangeTransaction.migrate(database: Database, oldVersion: Int, newVersion: Int) {
-        val store = if (oldVersion < 2) {
+        val store = if (oldVersion < 3) {
             database.createObjectStore("stats", KeyPath("key"))
         } else {
             objectStore("stats")
         }
-        if (oldVersion < 2) {
+        if (oldVersion < 3) {
             // no index
         }
     }

--- a/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/StatsStoreSchema.kt
+++ b/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/StatsStoreSchema.kt
@@ -1,0 +1,18 @@
+package io.github.irgaly.kottage.data.indexeddb.schema
+
+import com.juul.indexeddb.Database
+import com.juul.indexeddb.KeyPath
+import com.juul.indexeddb.VersionChangeTransaction
+
+class StatsStoreSchema: StoreSchema {
+    override fun VersionChangeTransaction.migrate(database: Database, oldVersion: Int, newVersion: Int) {
+        val store = if (oldVersion < 2) {
+            database.createObjectStore("stats", KeyPath("key"))
+        } else {
+            objectStore("stats")
+        }
+        if (oldVersion < 2) {
+            // no index
+        }
+    }
+}

--- a/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/StoreSchema.kt
+++ b/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/StoreSchema.kt
@@ -1,0 +1,19 @@
+package io.github.irgaly.kottage.data.indexeddb.schema
+
+import com.juul.indexeddb.Database
+import com.juul.indexeddb.VersionChangeTransaction
+
+interface StoreSchema {
+    fun VersionChangeTransaction.migrate(database: Database, oldVersion: Int, newVersion: Int)
+}
+
+fun allStoreSchemaNames(): Array<String> {
+    return arrayOf(
+        "item",
+        "item_event",
+        "item_list",
+        "item_list_stats",
+        "item_stats",
+        "stats",
+    )
+}

--- a/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/entity/Item.kt
+++ b/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/entity/Item.kt
@@ -1,0 +1,13 @@
+package io.github.irgaly.kottage.data.indexeddb.schema.entity
+
+external interface Item{
+    var key: String
+    var type: String
+    var string_value: String?
+    var long_value: Long?
+    var double_value: Double?
+    var bytes_value: ByteArray?
+    var created_at: Long
+    var last_read_at: Long
+    var expire_at: Long?
+}

--- a/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/entity/Item.kt
+++ b/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/entity/Item.kt
@@ -1,13 +1,16 @@
 package io.github.irgaly.kottage.data.indexeddb.schema.entity
 
-external interface Item{
+external interface Item {
     var key: String
     var type: String
     var string_value: String?
-    var long_value: Long?
+
+    // 64 bit 整数を保持するため Long を String で表現する
+    // JavaScript は 53 bit 整数までしか表現できない
+    var long_value: String?
     var double_value: Double?
     var bytes_value: ByteArray?
-    var created_at: Long
-    var last_read_at: Long
-    var expire_at: Long?
+    var created_at: Double
+    var last_read_at: Double
+    var expire_at: Double?
 }

--- a/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/entity/ItemEventType.kt
+++ b/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/entity/ItemEventType.kt
@@ -1,0 +1,7 @@
+package io.github.irgaly.kottage.data.indexeddb.schema.entity
+
+enum class ItemEventType {
+    Create,
+    Update,
+    Delete
+}

--- a/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/entity/Item_event.kt
+++ b/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/entity/Item_event.kt
@@ -2,8 +2,8 @@ package io.github.irgaly.kottage.data.indexeddb.schema.entity
 
 external interface Item_event {
   var id: String
-  var created_at: Long
-  var expire_at: Long?
+  var created_at: Double
+  var expire_at: Double?
   var item_type: String
   var item_key: String
   var item_list_id: String?

--- a/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/entity/Item_event.kt
+++ b/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/entity/Item_event.kt
@@ -1,0 +1,12 @@
+package io.github.irgaly.kottage.data.indexeddb.schema.entity
+
+external interface Item_event {
+  var id: String
+  var created_at: Long
+  var expire_at: Long?
+  var item_type: String
+  var item_key: String
+  var item_list_id: String?
+  var item_list_type: String?
+  var event_type: String // ItemEventType
+}

--- a/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/entity/Item_list.kt
+++ b/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/entity/Item_list.kt
@@ -7,7 +7,7 @@ external interface Item_list {
   var item_key: String?
   var previous_id: String?
   var next_id: String?
-  var expire_at: Long?
+  var expire_at: Double?
   var user_info: String?
   var user_previous_key: String?
   var user_current_key: String?

--- a/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/entity/Item_list.kt
+++ b/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/entity/Item_list.kt
@@ -1,0 +1,15 @@
+package io.github.irgaly.kottage.data.indexeddb.schema.entity
+
+external interface Item_list {
+  var id: String
+  var type: String
+  var item_type: String
+  var item_key: String?
+  var previous_id: String?
+  var next_id: String?
+  var expire_at: Long?
+  var user_info: String?
+  var user_previous_key: String?
+  var user_current_key: String?
+  var user_next_key: String?
+}

--- a/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/entity/Item_list_stats.kt
+++ b/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/entity/Item_list_stats.kt
@@ -2,7 +2,7 @@ package io.github.irgaly.kottage.data.indexeddb.schema.entity
 
 external interface Item_list_stats {
   var item_list_type: String
-  var count: Long
+  var count: Double
   var first_item_list_id: String
   var last_item_list_id: String
 }

--- a/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/entity/Item_list_stats.kt
+++ b/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/entity/Item_list_stats.kt
@@ -1,0 +1,8 @@
+package io.github.irgaly.kottage.data.indexeddb.schema.entity
+
+external interface Item_list_stats {
+  var item_list_type: String
+  var count: Long
+  var first_item_list_id: String
+  var last_item_list_id: String
+}

--- a/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/entity/Item_stats.kt
+++ b/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/entity/Item_stats.kt
@@ -2,6 +2,6 @@ package io.github.irgaly.kottage.data.indexeddb.schema.entity
 
 external interface Item_stats {
   var item_type: String
-  var count: Long
-  var event_count: Long
+  var count: Double
+  var event_count: Double
 }

--- a/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/entity/Item_stats.kt
+++ b/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/entity/Item_stats.kt
@@ -1,0 +1,7 @@
+package io.github.irgaly.kottage.data.indexeddb.schema.entity
+
+external interface Item_stats {
+  var item_type: String
+  var count: Long
+  var event_count: Long
+}

--- a/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/entity/Stats.kt
+++ b/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/entity/Stats.kt
@@ -1,0 +1,6 @@
+package io.github.irgaly.kottage.data.indexeddb.schema.entity
+
+external interface Stats {
+  var key: String
+  var last_evict_at: Long
+}

--- a/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/entity/Stats.kt
+++ b/kottage/data/indexeddb/src/jsMain/kotlin/io/github/irgaly/kottage/data/indexeddb/schema/entity/Stats.kt
@@ -2,5 +2,5 @@ package io.github.irgaly.kottage.data.indexeddb.schema.entity
 
 external interface Stats {
   var key: String
-  var last_evict_at: Long
+  var last_evict_at: Double
 }

--- a/kottage/data/sqlite/src/commonMain/sqldelight/io/github/irgaly/kottage/data/sqlite/item.sq
+++ b/kottage/data/sqlite/src/commonMain/sqldelight/io/github/irgaly/kottage/data/sqlite/item.sq
@@ -40,13 +40,13 @@ selectAllTypeExpiredKeys:
 SELECT key, type FROM item WHERE expire_at IS NOT NULL AND expire_at <= ? ORDER BY expire_at ASC;
 
 selectOlderCreatedKeys:
-SELECT key FROM item WHERE type = ? ORDER BY created_at;
+SELECT key FROM item WHERE type = ? ORDER BY created_at ASC;
 
 selectOlderCreatedKeysLimit:
 SELECT key FROM item WHERE type = ? ORDER BY created_at ASC LIMIT :limit;
 
 selectLeastRecentlyUsedKeys:
-SELECT key FROM item WHERE type = ? ORDER BY last_read_at;
+SELECT key FROM item WHERE type = ? ORDER BY last_read_at ASC;
 
 selectLeastRecentlyUsedKeysLimit:
 SELECT key FROM item WHERE type = ? ORDER BY last_read_at ASC LIMIT :limit;

--- a/kottage/data/sqlite/src/commonMain/sqldelight/io/github/irgaly/kottage/data/sqlite/item_list.sq
+++ b/kottage/data/sqlite/src/commonMain/sqldelight/io/github/irgaly/kottage/data/sqlite/item_list.sq
@@ -43,10 +43,10 @@ selectIdFromItem:
 SELECT id FROM item_list WHERE item_type = ? AND item_key = ?;
 
 selectInvalidatedItemBeforeExpireAt:
-SELECT id FROM item_list WHERE type = ? AND item_key ISNULL AND expire_at < ? ORDER BY expire_at LIMIT :limit;
+SELECT id FROM item_list WHERE type = ? AND item_key ISNULL AND expire_at < ? ORDER BY expire_at ASC LIMIT :limit;
 
 selectInvalidatedItem:
-SELECT id FROM item_list WHERE type = ? AND item_key ISNULL ORDER BY expire_at LIMIT :limit;
+SELECT id FROM item_list WHERE type = ? AND item_key ISNULL ORDER BY expire_at ASC LIMIT :limit;
 
 countByType:
 SELECT count(*) FROM item_list WHERE type = ?;

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/database/DatabaseConnection.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/database/DatabaseConnection.kt
@@ -21,7 +21,7 @@ internal actual class DatabaseConnection(
 
     actual suspend fun <R> transactionWithResult(bodyWithReturn: suspend Transaction.() -> R): R {
         val database = database.await()
-        return database.database.transaction(*allStoreSchemaNames()) {
+        return database.database.writeTransaction(*allStoreSchemaNames()) {
             with(Transaction(this)) {
                 bodyWithReturn()
             }
@@ -30,7 +30,7 @@ internal actual class DatabaseConnection(
 
     actual suspend fun transaction(body: suspend Transaction.() -> Unit) {
         val database = database.await()
-        database.database.transaction(*allStoreSchemaNames()) {
+        database.database.writeTransaction(*allStoreSchemaNames()) {
             with(Transaction(this)) {
                 body()
             }

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/database/DatabaseConnection.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/database/DatabaseConnection.kt
@@ -38,3 +38,12 @@ internal actual fun createDatabaseConnection(
     TODO()
 }
 
+internal actual suspend fun createOldDatabase(
+    fileName: String,
+    directoryPath: String,
+    environment: KottageEnvironment,
+    version: Int,
+    dispatcher: CoroutineDispatcher
+) {
+    TODO()
+}

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/database/DatabaseConnection.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/database/DatabaseConnection.kt
@@ -19,7 +19,7 @@ internal actual class DatabaseConnection(
         KottageIndexeddbDatabase.open(databaseName)
     }
 
-    actual suspend fun <R> transactionWithResult(bodyWithReturn: Transaction.() -> R): R {
+    actual suspend fun <R> transactionWithResult(bodyWithReturn: suspend Transaction.() -> R): R {
         val database = database.await()
         return database.database.transaction(*allStoreSchemaNames()) {
             with(Transaction(this)) {
@@ -28,7 +28,7 @@ internal actual class DatabaseConnection(
         }
     }
 
-    actual suspend fun transaction(body: Transaction.() -> Unit) {
+    actual suspend fun transaction(body: suspend Transaction.() -> Unit) {
         val database = database.await()
         database.database.transaction(*allStoreSchemaNames()) {
             with(Transaction(this)) {

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/database/DatabaseConnection.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/database/DatabaseConnection.kt
@@ -46,11 +46,11 @@ internal actual class DatabaseConnection(
     }
 
     actual suspend fun backupTo(file: String, directoryPath: String) {
-        // no operation with indexeddb
+        console.warn("backupTo() is not supported with indexeddb")
     }
 
     actual suspend fun compact() {
-        TODO("Not yet implemented")
+        // indexeddb is managed by browser, no need to maintain from application
     }
 }
 

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/database/DatabaseConnection.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/database/DatabaseConnection.kt
@@ -2,7 +2,12 @@ package io.github.irgaly.kottage.internal.database
 
 import io.github.irgaly.kottage.KottageEnvironment
 import io.github.irgaly.kottage.data.indexeddb.KottageIndexeddbDatabase
+import io.github.irgaly.kottage.data.indexeddb.extension.jso
 import io.github.irgaly.kottage.data.indexeddb.schema.allStoreSchemaNames
+import io.github.irgaly.kottage.data.indexeddb.schema.entity.Item
+import io.github.irgaly.kottage.data.indexeddb.schema.entity.Item_event
+import io.github.irgaly.kottage.data.indexeddb.schema.entity.Item_stats
+import io.github.irgaly.kottage.data.indexeddb.schema.entity.Stats
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.DelicateCoroutinesApi
@@ -73,5 +78,50 @@ internal actual suspend fun createOldDatabase(
     version: Int,
     dispatcher: CoroutineDispatcher
 ) {
-    TODO()
+    if (3 <= version) {
+        throw error("version 3 以降の indexeddb 初期化処理の実装が必要")
+    }
+    DatabaseConnection(
+        databaseName = "$directoryPath/$fileName",
+        dispatcher = dispatcher
+    ).transaction {
+        with(transaction) {
+            objectStore("item_stats").add(
+                jso<Item_stats> {
+                    item_type = "cache1"
+                    count = 1.toDouble()
+                    event_count = 1.toDouble()
+                }
+            )
+            objectStore("item_event").add(
+                jso<Item_event> {
+                    id = "61b658c4250a4e9a9d07a9815655c5e1"
+                    created_at = 1640995200000.toDouble()
+                    expire_at = 1643587200000.toDouble()
+                    item_type = "cache1"
+                    item_key = "cache1+key1"
+                    event_type = "Create"
+                }
+            )
+            objectStore("stats").add(
+                jso<Stats> {
+                    key = "kottage"
+                    last_evict_at = 1640995200000.toDouble()
+                }
+            )
+            objectStore("item").add(
+                jso<Item> {
+                    key = "cache1+key1"
+                    type = "cache1"
+                    string_value = "value1"
+                    long_value = null
+                    double_value = null
+                    bytes_value = null
+                    created_at = 1640995200000.toDouble()
+                    last_read_at = 1640995200000.toDouble()
+                    expire_at = 1643587200000.toDouble()
+                }
+            )
+        }
+    }
 }

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/database/DatabaseConnection.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/database/DatabaseConnection.kt
@@ -8,6 +8,7 @@ import io.github.irgaly.kottage.data.indexeddb.schema.entity.Item
 import io.github.irgaly.kottage.data.indexeddb.schema.entity.Item_event
 import io.github.irgaly.kottage.data.indexeddb.schema.entity.Item_stats
 import io.github.irgaly.kottage.data.indexeddb.schema.entity.Stats
+import io.github.irgaly.kottage.platform.Files
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.DelicateCoroutinesApi
@@ -51,7 +52,8 @@ internal actual class DatabaseConnection(
     }
 
     actual suspend fun backupTo(file: String, directoryPath: String) {
-        console.warn("backupTo() is not supported with indexeddb")
+        require(!file.contains(Files.separator)) { "file contains separator: $file" }
+        console.warn("backupTo() is not supported with indexeddb\n")
     }
 
     actual suspend fun compact() {

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/database/DatabaseConnection.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/database/DatabaseConnection.kt
@@ -15,7 +15,7 @@ internal actual class DatabaseConnection(
     private val dispatcher: CoroutineDispatcher = Dispatchers.Default
 ) {
     @OptIn(DelicateCoroutinesApi::class)
-    private val database = GlobalScope.async(dispatcher, CoroutineStart.LAZY) {
+    val database = GlobalScope.async(dispatcher, CoroutineStart.LAZY) {
         KottageIndexeddbDatabase.open(databaseName)
     }
 

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/database/Transaction.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/database/Transaction.kt
@@ -1,8 +1,7 @@
 package io.github.irgaly.kottage.internal.database
 
-import com.juul.indexeddb.Transaction
+import com.juul.indexeddb.WriteTransaction
 
 internal actual class Transaction(
-    val transaction: Transaction
-) {
-}
+    val transaction: WriteTransaction
+)

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/database/Transaction.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/database/Transaction.kt
@@ -1,0 +1,8 @@
+package io.github.irgaly.kottage.internal.database
+
+import com.juul.indexeddb.Transaction
+
+internal actual class Transaction(
+    val transaction: Transaction
+) {
+}

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/extension/FlowExtension.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/extension/FlowExtension.kt
@@ -1,0 +1,11 @@
+package io.github.irgaly.kottage.internal.extension
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.takeWhile
+
+internal fun <T> Flow<T>.take(count: Long): Flow<T> {
+    var consumed = 0L
+    return takeWhile { consumed < count }
+        .onEach { consumed++ }
+}

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/extension/IndexxeddbExtension.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/extension/IndexxeddbExtension.kt
@@ -17,7 +17,7 @@ internal suspend fun <Item, PrimaryKey, SortKey> Queryable.iterateWithChunk(
     chunkSize: Long,
     primaryKey: (item: Item) -> PrimaryKey,
     sortKey: (item: Item) -> SortKey,
-    initialRange: Key,
+    initialRange: Key?,
     resumeRange: (lastItem: Item) -> Key,
     limit: Long? = null,
     block: suspend (items: Item) -> Boolean

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/extension/IndexxeddbExtension.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/extension/IndexxeddbExtension.kt
@@ -1,0 +1,53 @@
+package io.github.irgaly.kottage.internal.extension
+
+import com.juul.indexeddb.Key
+import com.juul.indexeddb.Queryable
+import com.juul.indexeddb.WriteTransaction
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
+
+/**
+ * chunkSize ごとにアイテムを処理する
+ * 重複可能な SortKey にも対応
+ *
+ * cursor を処理している間に対象が delete されると cursor がずれてしまうため
+ * chunkSize ごとに cursor を閉じて処理する
+ */
+internal suspend fun <Item, SortKey> Queryable.iterateWithChunk(
+    transaction: WriteTransaction,
+    chunkSize: Long,
+    primaryKey: (item: Item) -> String,
+    sortKey: (item: Item) -> SortKey,
+    initialRange: Key,
+    resumeRange: (lastItem: Item) -> Key,
+    block: suspend (items: Item) -> Unit
+) {
+    with(transaction) {
+        var hasNext = true
+        var consumedKeys = mapOf<SortKey, Set<String>>()
+        var nextRange = initialRange
+        while (hasNext) {
+            val results = openCursor(nextRange).map { cursor ->
+                cursor.value.unsafeCast<Item>()
+            }.filter {
+                // すでに処理した項目はスキップする
+                consumedKeys[sortKey(it)]?.let { consumed ->
+                    (primaryKey(it) !in consumed)
+                } ?: true
+            }.take(chunkSize).toList()
+            results.forEach { block(it) }
+            results.lastOrNull()?.let { lastItem ->
+                val nextSortKey = sortKey(lastItem)
+                nextRange = resumeRange(lastItem)
+                val consumed = results.filter {
+                    (sortKey(it) == nextSortKey)
+                }.map { primaryKey(it) }.toSet()
+                    .union(consumedKeys[nextSortKey] ?: emptySet())
+                // nextSortKey の項目だけを記憶する
+                consumedKeys = mapOf(nextSortKey to consumed)
+            }
+            hasNext = (chunkSize <= results.size)
+        }
+    }
+}

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemEventRepository.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemEventRepository.kt
@@ -1,16 +1,27 @@
 package io.github.irgaly.kottage.internal.repository
 
+import com.juul.indexeddb.Cursor
+import com.juul.indexeddb.Key
 import com.juul.indexeddb.ObjectStore
 import com.juul.indexeddb.WriteTransaction
-import io.github.irgaly.kottage.data.indexeddb.KottageIndexeddbDatabase
+import com.juul.indexeddb.bound
+import com.juul.indexeddb.lowerBound
+import com.juul.indexeddb.upperBound
+import io.github.irgaly.kottage.data.indexeddb.extension.jso
+import io.github.irgaly.kottage.data.indexeddb.schema.entity.Item_event
+import io.github.irgaly.kottage.data.indexeddb.schema.entity.Item_stats
 import io.github.irgaly.kottage.internal.database.Transaction
+import io.github.irgaly.kottage.internal.extension.take
 import io.github.irgaly.kottage.internal.model.ItemEvent
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
 
-internal class KottageIndexeddbItemEventRepository(
-    private val database: KottageIndexeddbDatabase
-) : KottageItemEventRepository {
+internal class KottageIndexeddbItemEventRepository : KottageItemEventRepository {
     override suspend fun create(transaction: Transaction, itemEvent: ItemEvent) {
-        TODO("Not yet implemented")
+        transaction.store { store ->
+            store.add(itemEvent.toEntity())
+        }
     }
 
     override suspend fun selectAfter(
@@ -19,11 +30,45 @@ internal class KottageIndexeddbItemEventRepository(
         itemType: String?,
         limit: Long?
     ): List<ItemEvent> {
-        TODO("Not yet implemented")
+        return transaction.store { store ->
+            (if (itemType != null) {
+                store.index("item_event_item_type_created_at")
+                    .openCursor(
+                        // item_type = itemType && createdAt < created_at
+                        bound(
+                            arrayOf(itemType, createdAt),
+                            arrayOf(itemType, emptyArray<Any>()),
+                            lowerOpen = true
+                        )
+                    )
+            } else {
+                store.index("item_event_created_at")
+                    .openCursor(
+                        // createdAt < created_at
+                        lowerBound(createdAt, true)
+                    )
+            }).let {
+                if (limit != null) it.take(limit) else it
+            }.map { cursor ->
+                cursor.value.unsafeCast<Item_event>().toDomain()
+            }.toList()
+        }
     }
 
     override suspend fun getLatestCreatedAt(transaction: Transaction, itemType: String): Long? {
-        TODO("Not yet implemented")
+        return transaction.store { store ->
+            store.index("item_event_item_type_created_at")
+                .openCursor(
+                    // item_type = itemType && created_at DESC
+                    bound(
+                        arrayOf(itemType),
+                        arrayOf(itemType, emptyArray<Any>())
+                    ),
+                    Cursor.Direction.Previous
+                ).map { cursor ->
+                    cursor.value.unsafeCast<Item_event>().created_at
+                }.firstOrNull()
+        }
     }
 
     override suspend fun getExpiredIds(
@@ -32,50 +77,153 @@ internal class KottageIndexeddbItemEventRepository(
         itemType: String?,
         receiver: suspend (id: String, itemType: String) -> Unit
     ) {
-        TODO("Not yet implemented")
+        transaction.store { store ->
+            if (itemType != null) {
+                store.index("item_event_item_type_expire_at").openKeyCursor(
+                    // item_type = itemType && expire_at <= now
+                    bound(
+                        arrayOf(itemType),
+                        arrayOf(itemType, now)
+                    )
+                ).collect { cursor ->
+                    val id = cursor.primaryKey.unsafeCast<String>()
+                    receiver(id, itemType)
+                }
+            } else {
+                store.index("item_event_expire_at").openCursor(
+                    // expire_at <= now
+                    upperBound(now)
+                ).collect { cursor ->
+                    val event =
+                        cursor.value.unsafeCast<Item_event>()
+                    receiver(event.id, event.item_type)
+                }
+            }
+        }
     }
 
     override suspend fun getCount(transaction: Transaction, itemType: String): Long {
-        TODO("Not yet implemented")
+        return transaction.store { store ->
+            store.index("item_event_item_type_created_at").count(
+                // item_type = itemType
+                bound(
+                    arrayOf(itemType),
+                    arrayOf(itemType, emptyArray<Any>())
+                )
+            ).toLong()
+        }
     }
 
     override suspend fun delete(transaction: Transaction, id: String) {
-        TODO("Not yet implemented")
+        transaction.store { store ->
+            store.delete(Key(id))
+        }
     }
 
     override suspend fun deleteOlderEvents(transaction: Transaction, itemType: String, limit: Long) {
-        TODO("Not yet implemented")
+        transaction.store { store ->
+            store.index("item_event_item_type_created_at").openCursor(
+                // item_type = itemType
+                bound(
+                    arrayOf(itemType),
+                    arrayOf(itemType, emptyArray<Any>())
+                )
+            ).take(limit).collect { cursor ->
+                cursor.delete()
+            }
+        }
     }
 
     override suspend fun deleteBefore(transaction: Transaction, createdAt: Long) {
-        TODO("Not yet implemented")
+        transaction.store { store ->
+            store.index("item_event_created_at").openCursor(
+                // created_at < createdAt
+                upperBound(createdAt, true)
+            ).collect { cursor ->
+                cursor.delete()
+            }
+        }
     }
 
     override suspend fun deleteAll(transaction: Transaction, itemType: String) {
-        TODO("Not yet implemented")
+        transaction.store { store ->
+            store.index("item_event_created_at").openCursor(
+                // item_type = itemType
+                bound(
+                    arrayOf(itemType),
+                    arrayOf(itemType, emptyArray<Any>())
+                )
+            ).collect { cursor ->
+                cursor.delete()
+            }
+        }
     }
 
     override suspend fun deleteAllList(transaction: Transaction, listType: String) {
-        TODO("Not yet implemented")
+        transaction.store { store ->
+            store.index("item_event_item_list_type_created_at").openCursor(
+                // item_list_type = listType
+                bound(
+                    arrayOf(listType),
+                    arrayOf(listType, emptyArray<Any>())
+                )
+            ).collect { cursor ->
+                cursor.delete()
+            }
+        }
     }
 
     override suspend fun getStatsCount(transaction: Transaction, itemType: String): Long {
-        TODO("Not yet implemented")
+        return transaction.statsStore { store ->
+            store.get(Key(itemType))?.unsafeCast<Item_stats>()?.event_count ?: 0L
+        }
     }
 
     override suspend fun incrementStatsCount(transaction: Transaction, itemType: String, count: Long) {
-        TODO("Not yet implemented")
+        transaction.statsStore { store ->
+            val stats = getOrCreate(store, itemType)
+            stats.event_count += 1
+            store.put(stats)
+        }
     }
 
     override suspend fun decrementStatsCount(transaction: Transaction, itemType: String, count: Long) {
-        TODO("Not yet implemented")
+        transaction.statsStore { store ->
+            val stats = getOrCreate(store, itemType)
+            stats.event_count -= 1
+            store.put(stats)
+        }
     }
 
     override suspend fun updateStatsCount(transaction: Transaction, itemType: String, count: Long) {
-        TODO("Not yet implemented")
+        transaction.statsStore { store ->
+            val stats = getOrCreate(store, itemType)
+            stats.event_count = count
+            store.put(stats)
+        }
+    }
+
+    private suspend fun WriteTransaction.getOrCreate(
+        store: ObjectStore,
+        itemType: String
+    ): Item_stats {
+        var stats = store.get(Key(itemType))?.unsafeCast<Item_stats>()
+        if (stats == null) {
+            stats = jso {
+                item_type = itemType
+                count = 0
+                event_count = 0
+            }
+            store.add(stats)
+        }
+        return stats
     }
 
     private inline fun <R> Transaction.store(block: WriteTransaction.(store: ObjectStore) -> R): R {
         return with(transaction) { block(transaction.objectStore("item_event")) }
+    }
+
+    private inline fun <R> Transaction.statsStore(block: WriteTransaction.(store: ObjectStore) -> R): R {
+        return with(transaction) { block(transaction.objectStore("item_stats")) }
     }
 }

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemEventRepository.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemEventRepository.kt
@@ -1,9 +1,14 @@
 package io.github.irgaly.kottage.internal.repository
 
+import com.juul.indexeddb.ObjectStore
+import com.juul.indexeddb.WriteTransaction
+import io.github.irgaly.kottage.data.indexeddb.KottageIndexeddbDatabase
 import io.github.irgaly.kottage.internal.database.Transaction
 import io.github.irgaly.kottage.internal.model.ItemEvent
 
-internal class KottageIndexeddbItemEventRepository : KottageItemEventRepository {
+internal class KottageIndexeddbItemEventRepository(
+    private val database: KottageIndexeddbDatabase
+) : KottageItemEventRepository {
     override suspend fun create(transaction: Transaction, itemEvent: ItemEvent) {
         TODO("Not yet implemented")
     }
@@ -68,5 +73,9 @@ internal class KottageIndexeddbItemEventRepository : KottageItemEventRepository 
 
     override suspend fun updateStatsCount(transaction: Transaction, itemType: String, count: Long) {
         TODO("Not yet implemented")
+    }
+
+    private inline fun <R> Transaction.store(block: WriteTransaction.(store: ObjectStore) -> R): R {
+        return with(transaction) { block(transaction.objectStore("item_event")) }
     }
 }

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemEventRepository.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemEventRepository.kt
@@ -7,15 +7,59 @@ internal class KottageIndexeddbItemEventRepository : KottageItemEventRepository 
         TODO("Not yet implemented")
     }
 
-    override fun selectAfter(itemType: String, createdAt: Long): List<ItemEvent> {
+    override fun selectAfter(createdAt: Long, itemType: String?, limit: Long?): List<ItemEvent> {
         TODO("Not yet implemented")
     }
 
-    override fun selectAfter(createdAt: Long): List<ItemEvent> {
+    override fun getLatestCreatedAt(itemType: String): Long? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getExpiredIds(
+        now: Long,
+        itemType: String?,
+        receiver: (id: String, itemType: String) -> Unit
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getCount(itemType: String): Long {
+        TODO("Not yet implemented")
+    }
+
+    override fun delete(id: String) {
+        TODO("Not yet implemented")
+    }
+
+    override fun deleteOlderEvents(itemType: String, limit: Long) {
         TODO("Not yet implemented")
     }
 
     override fun deleteBefore(createdAt: Long) {
+        TODO("Not yet implemented")
+    }
+
+    override fun deleteAll(itemType: String) {
+        TODO("Not yet implemented")
+    }
+
+    override fun deleteAllList(listType: String) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getStatsCount(itemType: String): Long {
+        TODO("Not yet implemented")
+    }
+
+    override fun incrementStatsCount(itemType: String, count: Long) {
+        TODO("Not yet implemented")
+    }
+
+    override fun decrementStatsCount(itemType: String, count: Long) {
+        TODO("Not yet implemented")
+    }
+
+    override fun updateStatsCount(itemType: String, count: Long) {
         TODO("Not yet implemented")
     }
 }

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemEventRepository.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemEventRepository.kt
@@ -4,11 +4,11 @@ import io.github.irgaly.kottage.internal.database.Transaction
 import io.github.irgaly.kottage.internal.model.ItemEvent
 
 internal class KottageIndexeddbItemEventRepository : KottageItemEventRepository {
-    override fun create(transaction: Transaction, itemEvent: ItemEvent) {
+    override suspend fun create(transaction: Transaction, itemEvent: ItemEvent) {
         TODO("Not yet implemented")
     }
 
-    override fun selectAfter(
+    override suspend fun selectAfter(
         transaction: Transaction,
         createdAt: Long,
         itemType: String?,
@@ -17,56 +17,56 @@ internal class KottageIndexeddbItemEventRepository : KottageItemEventRepository 
         TODO("Not yet implemented")
     }
 
-    override fun getLatestCreatedAt(transaction: Transaction, itemType: String): Long? {
+    override suspend fun getLatestCreatedAt(transaction: Transaction, itemType: String): Long? {
         TODO("Not yet implemented")
     }
 
-    override fun getExpiredIds(
+    override suspend fun getExpiredIds(
         transaction: Transaction,
         now: Long,
         itemType: String?,
-        receiver: (id: String, itemType: String) -> Unit
+        receiver: suspend (id: String, itemType: String) -> Unit
     ) {
         TODO("Not yet implemented")
     }
 
-    override fun getCount(transaction: Transaction, itemType: String): Long {
+    override suspend fun getCount(transaction: Transaction, itemType: String): Long {
         TODO("Not yet implemented")
     }
 
-    override fun delete(transaction: Transaction, id: String) {
+    override suspend fun delete(transaction: Transaction, id: String) {
         TODO("Not yet implemented")
     }
 
-    override fun deleteOlderEvents(transaction: Transaction, itemType: String, limit: Long) {
+    override suspend fun deleteOlderEvents(transaction: Transaction, itemType: String, limit: Long) {
         TODO("Not yet implemented")
     }
 
-    override fun deleteBefore(transaction: Transaction, createdAt: Long) {
+    override suspend fun deleteBefore(transaction: Transaction, createdAt: Long) {
         TODO("Not yet implemented")
     }
 
-    override fun deleteAll(transaction: Transaction, itemType: String) {
+    override suspend fun deleteAll(transaction: Transaction, itemType: String) {
         TODO("Not yet implemented")
     }
 
-    override fun deleteAllList(transaction: Transaction, listType: String) {
+    override suspend fun deleteAllList(transaction: Transaction, listType: String) {
         TODO("Not yet implemented")
     }
 
-    override fun getStatsCount(transaction: Transaction, itemType: String): Long {
+    override suspend fun getStatsCount(transaction: Transaction, itemType: String): Long {
         TODO("Not yet implemented")
     }
 
-    override fun incrementStatsCount(transaction: Transaction, itemType: String, count: Long) {
+    override suspend fun incrementStatsCount(transaction: Transaction, itemType: String, count: Long) {
         TODO("Not yet implemented")
     }
 
-    override fun decrementStatsCount(transaction: Transaction, itemType: String, count: Long) {
+    override suspend fun decrementStatsCount(transaction: Transaction, itemType: String, count: Long) {
         TODO("Not yet implemented")
     }
 
-    override fun updateStatsCount(transaction: Transaction, itemType: String, count: Long) {
+    override suspend fun updateStatsCount(transaction: Transaction, itemType: String, count: Long) {
         TODO("Not yet implemented")
     }
 }

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemEventRepository.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemEventRepository.kt
@@ -1,21 +1,28 @@
 package io.github.irgaly.kottage.internal.repository
 
+import io.github.irgaly.kottage.internal.database.Transaction
 import io.github.irgaly.kottage.internal.model.ItemEvent
 
 internal class KottageIndexeddbItemEventRepository : KottageItemEventRepository {
-    override fun create(itemEvent: ItemEvent) {
+    override fun create(transaction: Transaction, itemEvent: ItemEvent) {
         TODO("Not yet implemented")
     }
 
-    override fun selectAfter(createdAt: Long, itemType: String?, limit: Long?): List<ItemEvent> {
+    override fun selectAfter(
+        transaction: Transaction,
+        createdAt: Long,
+        itemType: String?,
+        limit: Long?
+    ): List<ItemEvent> {
         TODO("Not yet implemented")
     }
 
-    override fun getLatestCreatedAt(itemType: String): Long? {
+    override fun getLatestCreatedAt(transaction: Transaction, itemType: String): Long? {
         TODO("Not yet implemented")
     }
 
     override fun getExpiredIds(
+        transaction: Transaction,
         now: Long,
         itemType: String?,
         receiver: (id: String, itemType: String) -> Unit
@@ -23,43 +30,43 @@ internal class KottageIndexeddbItemEventRepository : KottageItemEventRepository 
         TODO("Not yet implemented")
     }
 
-    override fun getCount(itemType: String): Long {
+    override fun getCount(transaction: Transaction, itemType: String): Long {
         TODO("Not yet implemented")
     }
 
-    override fun delete(id: String) {
+    override fun delete(transaction: Transaction, id: String) {
         TODO("Not yet implemented")
     }
 
-    override fun deleteOlderEvents(itemType: String, limit: Long) {
+    override fun deleteOlderEvents(transaction: Transaction, itemType: String, limit: Long) {
         TODO("Not yet implemented")
     }
 
-    override fun deleteBefore(createdAt: Long) {
+    override fun deleteBefore(transaction: Transaction, createdAt: Long) {
         TODO("Not yet implemented")
     }
 
-    override fun deleteAll(itemType: String) {
+    override fun deleteAll(transaction: Transaction, itemType: String) {
         TODO("Not yet implemented")
     }
 
-    override fun deleteAllList(listType: String) {
+    override fun deleteAllList(transaction: Transaction, listType: String) {
         TODO("Not yet implemented")
     }
 
-    override fun getStatsCount(itemType: String): Long {
+    override fun getStatsCount(transaction: Transaction, itemType: String): Long {
         TODO("Not yet implemented")
     }
 
-    override fun incrementStatsCount(itemType: String, count: Long) {
+    override fun incrementStatsCount(transaction: Transaction, itemType: String, count: Long) {
         TODO("Not yet implemented")
     }
 
-    override fun decrementStatsCount(itemType: String, count: Long) {
+    override fun decrementStatsCount(transaction: Transaction, itemType: String, count: Long) {
         TODO("Not yet implemented")
     }
 
-    override fun updateStatsCount(itemType: String, count: Long) {
+    override fun updateStatsCount(transaction: Transaction, itemType: String, count: Long) {
         TODO("Not yet implemented")
     }
 }

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemEventRepository.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemEventRepository.kt
@@ -182,7 +182,7 @@ internal class KottageIndexeddbItemEventRepository : KottageItemEventRepository 
     override suspend fun incrementStatsCount(transaction: Transaction, itemType: String, count: Long) {
         transaction.statsStore { store ->
             val stats = getOrCreate(store, itemType)
-            stats.event_count += 1
+            stats.event_count += count
             store.put(stats)
         }
     }
@@ -190,7 +190,7 @@ internal class KottageIndexeddbItemEventRepository : KottageItemEventRepository 
     override suspend fun decrementStatsCount(transaction: Transaction, itemType: String, count: Long) {
         transaction.statsStore { store ->
             val stats = getOrCreate(store, itemType)
-            stats.event_count -= 1
+            stats.event_count -= count
             store.put(stats)
         }
     }

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemListRepository.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemListRepository.kt
@@ -158,7 +158,7 @@ internal class KottageIndexeddbItemListRepository : KottageItemListRepository {
 
     override suspend fun getCount(transaction: Transaction, type: String): Long {
         return transaction.store { store ->
-            store.index("item_list_item_type").count(
+            store.index("item_list_type").count(
                 Key(type)
             ).toLong()
         }
@@ -166,7 +166,7 @@ internal class KottageIndexeddbItemListRepository : KottageItemListRepository {
 
     override suspend fun getInvalidatedItemCount(transaction: Transaction, type: String): Long {
         return transaction.store { store ->
-            store.index("item_list_item_type").openCursor(
+            store.index("item_list_type").openCursor(
                 Key(type)
             ).count { cursor ->
                 (cursor.value.unsafeCast<Item_list>().item_key == null)

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemListRepository.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemListRepository.kt
@@ -63,7 +63,7 @@ internal class KottageIndexeddbItemListRepository : KottageItemListRepository {
                 ?.let { list ->
                     list.item_key = itemKey
                     list.item_type = itemType
-                    list.expire_at = expireAt
+                    list.expire_at = expireAt?.toDouble()
                     store.put(list)
                 }
         }
@@ -74,7 +74,7 @@ internal class KottageIndexeddbItemListRepository : KottageItemListRepository {
             store.get(Key(id))
                 ?.unsafeCast<Item_list>()
                 ?.let { list ->
-                    list.expire_at = expireAt
+                    list.expire_at = expireAt?.toDouble()
                     store.put(list)
                 }
         }
@@ -136,7 +136,7 @@ internal class KottageIndexeddbItemListRepository : KottageItemListRepository {
                     // type = type && expire_at < beforeExpireAt
                     bound(
                         arrayOf(type),
-                        arrayOf(type, beforeExpireAt),
+                        arrayOf(type, beforeExpireAt.toDouble()),
                         upperOpen = true
                     )
                 )
@@ -213,7 +213,7 @@ internal class KottageIndexeddbItemListRepository : KottageItemListRepository {
         transaction.statsStore { store ->
             store.add(jso<Item_list_stats> {
                 item_list_type = type
-                this.count = count
+                this.count = count.toDouble()
                 first_item_list_id = firstItemListEntryId
                 last_item_list_id = lastItemListEntryId
             })
@@ -228,57 +228,52 @@ internal class KottageIndexeddbItemListRepository : KottageItemListRepository {
 
     override suspend fun getStatsCount(transaction: Transaction, type: String): Long {
         return transaction.statsStore { store ->
-            store.get(Key(type))?.unsafeCast<Item_list_stats>()?.count ?: 0L
+            store.get(Key(type))?.unsafeCast<Item_list_stats>()?.count?.toLong() ?: 0L
         }
     }
 
     override suspend fun incrementStatsCount(transaction: Transaction, type: String, count: Long) {
         transaction.statsStore { store ->
-            store.get(Key(type))
-                ?.unsafeCast<Item_list_stats>()?.let { stats ->
-                    stats.count += count
-                    store.put(stats)
-                }
+            store.get(Key(type))?.unsafeCast<Item_list_stats>()?.let { stats ->
+                stats.count += count.toDouble()
+                store.put(stats)
+            }
         }
     }
 
     override suspend fun decrementStatsCount(transaction: Transaction, type: String, count: Long) {
         transaction.statsStore { store ->
-            store.get(Key(type))
-                ?.unsafeCast<Item_list_stats>()?.let { stats ->
-                    stats.count -= count
-                    store.put(stats)
-                }
+            store.get(Key(type))?.unsafeCast<Item_list_stats>()?.let { stats ->
+                stats.count -= count.toDouble()
+                store.put(stats)
+            }
         }
     }
 
     override suspend fun updateStatsCount(transaction: Transaction, type: String, count: Long) {
         transaction.statsStore { store ->
-            store.get(Key(type))
-                ?.unsafeCast<Item_list_stats>()?.let { stats ->
-                    stats.count = count
-                    store.put(stats)
-                }
+            store.get(Key(type))?.unsafeCast<Item_list_stats>()?.let { stats ->
+                stats.count = count.toDouble()
+                store.put(stats)
+            }
         }
     }
 
     override suspend fun updateStatsFirstItem(transaction: Transaction, type: String, id: String) {
         transaction.statsStore { store ->
-            store.get(Key(type))
-                ?.unsafeCast<Item_list_stats>()?.let { stats ->
-                    stats.first_item_list_id = id
-                    store.put(stats)
-                }
+            store.get(Key(type))?.unsafeCast<Item_list_stats>()?.let { stats ->
+                stats.first_item_list_id = id
+                store.put(stats)
+            }
         }
     }
 
     override suspend fun updateStatsLastItem(transaction: Transaction, type: String, id: String) {
         transaction.statsStore { store ->
-            store.get(Key(type))
-                ?.unsafeCast<Item_list_stats>()?.let { stats ->
-                    stats.last_item_list_id = id
-                    store.put(stats)
-                }
+            store.get(Key(type))?.unsafeCast<Item_list_stats>()?.let { stats ->
+                stats.last_item_list_id = id
+                store.put(stats)
+            }
         }
     }
 

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemListRepository.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemListRepository.kt
@@ -1,46 +1,54 @@
 package io.github.irgaly.kottage.internal.repository
 
+import io.github.irgaly.kottage.internal.database.Transaction
 import io.github.irgaly.kottage.internal.model.ItemListEntry
 import io.github.irgaly.kottage.internal.model.ItemListStats
 
 internal class KottageIndexeddbItemListRepository : KottageItemListRepository {
-    override fun upsert(entry: ItemListEntry) {
+    override fun upsert(transaction: Transaction, entry: ItemListEntry) {
         TODO("Not yet implemented")
     }
 
-    override fun updatePreviousId(id: String, previousId: String?) {
+    override fun updatePreviousId(transaction: Transaction, id: String, previousId: String?) {
         TODO("Not yet implemented")
     }
 
-    override fun updateNextId(id: String, nextId: String?) {
+    override fun updateNextId(transaction: Transaction, id: String, nextId: String?) {
         TODO("Not yet implemented")
     }
 
-    override fun updateItemKey(id: String, itemType: String, itemKey: String?, expireAt: Long?) {
+    override fun updateItemKey(
+        transaction: Transaction,
+        id: String,
+        itemType: String,
+        itemKey: String?,
+        expireAt: Long?
+    ) {
         TODO("Not yet implemented")
     }
 
-    override fun updateExpireAt(id: String, expireAt: Long?) {
+    override fun updateExpireAt(transaction: Transaction, id: String, expireAt: Long?) {
         TODO("Not yet implemented")
     }
 
-    override fun removeItemKey(id: String) {
+    override fun removeItemKey(transaction: Transaction, id: String) {
         TODO("Not yet implemented")
     }
 
-    override fun removeUserData(id: String) {
+    override fun removeUserData(transaction: Transaction, id: String) {
         TODO("Not yet implemented")
     }
 
-    override fun get(id: String): ItemListEntry? {
+    override fun get(transaction: Transaction, id: String): ItemListEntry? {
         TODO("Not yet implemented")
     }
 
-    override fun getIds(itemType: String, itemKey: String): List<String> {
+    override fun getIds(transaction: Transaction, itemType: String, itemKey: String): List<String> {
         TODO("Not yet implemented")
     }
 
     override fun getInvalidatedItemIds(
+        transaction: Transaction,
         type: String,
         beforeExpireAt: Long?,
         limit: Long
@@ -48,27 +56,28 @@ internal class KottageIndexeddbItemListRepository : KottageItemListRepository {
         TODO("Not yet implemented")
     }
 
-    override fun getCount(type: String): Long {
+    override fun getCount(transaction: Transaction, type: String): Long {
         TODO("Not yet implemented")
     }
 
-    override fun getInvalidatedItemCount(type: String): Long {
+    override fun getInvalidatedItemCount(transaction: Transaction, type: String): Long {
         TODO("Not yet implemented")
     }
 
-    override fun getAllTypes(receiver: (type: String) -> Unit) {
+    override fun getAllTypes(transaction: Transaction, receiver: (type: String) -> Unit) {
         TODO("Not yet implemented")
     }
 
-    override fun delete(id: String) {
+    override fun delete(transaction: Transaction, id: String) {
         TODO("Not yet implemented")
     }
 
-    override fun deleteAll(type: String) {
+    override fun deleteAll(transaction: Transaction, type: String) {
         TODO("Not yet implemented")
     }
 
     override fun createStats(
+        transaction: Transaction,
         type: String,
         count: Long,
         firstItemListEntryId: String,
@@ -77,35 +86,35 @@ internal class KottageIndexeddbItemListRepository : KottageItemListRepository {
         TODO("Not yet implemented")
     }
 
-    override fun getStats(type: String): ItemListStats? {
+    override fun getStats(transaction: Transaction, type: String): ItemListStats? {
         TODO("Not yet implemented")
     }
 
-    override fun getStatsCount(type: String): Long {
+    override fun getStatsCount(transaction: Transaction, type: String): Long {
         TODO("Not yet implemented")
     }
 
-    override fun incrementStatsCount(type: String, count: Long) {
+    override fun incrementStatsCount(transaction: Transaction, type: String, count: Long) {
         TODO("Not yet implemented")
     }
 
-    override fun decrementStatsCount(type: String, count: Long) {
+    override fun decrementStatsCount(transaction: Transaction, type: String, count: Long) {
         TODO("Not yet implemented")
     }
 
-    override fun updateStatsCount(type: String, count: Long) {
+    override fun updateStatsCount(transaction: Transaction, type: String, count: Long) {
         TODO("Not yet implemented")
     }
 
-    override fun updateStatsFirstItem(type: String, id: String) {
+    override fun updateStatsFirstItem(transaction: Transaction, type: String, id: String) {
         TODO("Not yet implemented")
     }
 
-    override fun updateStatsLastItem(type: String, id: String) {
+    override fun updateStatsLastItem(transaction: Transaction, type: String, id: String) {
         TODO("Not yet implemented")
     }
 
-    override fun deleteStats(type: String) {
+    override fun deleteStats(transaction: Transaction, type: String) {
         TODO("Not yet implemented")
     }
 }

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemListRepository.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemListRepository.kt
@@ -1,10 +1,15 @@
 package io.github.irgaly.kottage.internal.repository
 
+import com.juul.indexeddb.ObjectStore
+import com.juul.indexeddb.WriteTransaction
+import io.github.irgaly.kottage.data.indexeddb.KottageIndexeddbDatabase
 import io.github.irgaly.kottage.internal.database.Transaction
 import io.github.irgaly.kottage.internal.model.ItemListEntry
 import io.github.irgaly.kottage.internal.model.ItemListStats
 
-internal class KottageIndexeddbItemListRepository : KottageItemListRepository {
+internal class KottageIndexeddbItemListRepository(
+    private val database: KottageIndexeddbDatabase
+) : KottageItemListRepository {
     override suspend fun upsert(transaction: Transaction, entry: ItemListEntry) {
         TODO("Not yet implemented")
     }
@@ -116,5 +121,9 @@ internal class KottageIndexeddbItemListRepository : KottageItemListRepository {
 
     override suspend fun deleteStats(transaction: Transaction, type: String) {
         TODO("Not yet implemented")
+    }
+
+    private inline fun <R> Transaction.store(block: WriteTransaction.(store: ObjectStore) -> R): R {
+        return with(transaction) { block(transaction.objectStore("item_list")) }
     }
 }

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemListRepository.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemListRepository.kt
@@ -1,14 +1,27 @@
 package io.github.irgaly.kottage.internal.repository
 
+import com.juul.indexeddb.Key
 import com.juul.indexeddb.ObjectStore
 import com.juul.indexeddb.WriteTransaction
+import com.juul.indexeddb.bound
+import com.juul.indexeddb.external.IDBKeyRange.Companion.only
+import io.github.irgaly.kottage.data.indexeddb.extension.jso
+import io.github.irgaly.kottage.data.indexeddb.schema.entity.Item_list
+import io.github.irgaly.kottage.data.indexeddb.schema.entity.Item_list_stats
 import io.github.irgaly.kottage.internal.database.Transaction
+import io.github.irgaly.kottage.internal.extension.take
 import io.github.irgaly.kottage.internal.model.ItemListEntry
 import io.github.irgaly.kottage.internal.model.ItemListStats
+import kotlinx.coroutines.flow.count
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.toList
 
 internal class KottageIndexeddbItemListRepository : KottageItemListRepository {
     override suspend fun upsert(transaction: Transaction, entry: ItemListEntry) {
-        TODO("Not yet implemented")
+        transaction.store { store ->
+            store.put(entry.toEntity())
+        }
     }
 
     override suspend fun updatePreviousId(
@@ -16,11 +29,25 @@ internal class KottageIndexeddbItemListRepository : KottageItemListRepository {
         id: String,
         previousId: String?
     ) {
-        TODO("Not yet implemented")
+        transaction.store { store ->
+            store.get(Key(id))
+                ?.unsafeCast<Item_list>()
+                ?.let { list ->
+                    list.previous_id = previousId
+                    store.put(list)
+                }
+        }
     }
 
     override suspend fun updateNextId(transaction: Transaction, id: String, nextId: String?) {
-        TODO("Not yet implemented")
+        transaction.store { store ->
+            store.get(Key(id))
+                ?.unsafeCast<Item_list>()
+                ?.let { list ->
+                    list.next_id = nextId
+                    store.put(list)
+                }
+        }
     }
 
     override suspend fun updateItemKey(
@@ -30,27 +57,71 @@ internal class KottageIndexeddbItemListRepository : KottageItemListRepository {
         itemKey: String?,
         expireAt: Long?
     ) {
-        TODO("Not yet implemented")
+        transaction.store { store ->
+            store.get(Key(id))
+                ?.unsafeCast<Item_list>()
+                ?.let { list ->
+                    list.item_key = itemKey
+                    list.item_type = itemType
+                    list.expire_at = expireAt
+                    store.put(list)
+                }
+        }
     }
 
     override suspend fun updateExpireAt(transaction: Transaction, id: String, expireAt: Long?) {
-        TODO("Not yet implemented")
+        transaction.store { store ->
+            store.get(Key(id))
+                ?.unsafeCast<Item_list>()
+                ?.let { list ->
+                    list.expire_at = expireAt
+                    store.put(list)
+                }
+        }
     }
 
     override suspend fun removeItemKey(transaction: Transaction, id: String) {
-        TODO("Not yet implemented")
+        transaction.store { store ->
+            store.get(Key(id))
+                ?.unsafeCast<Item_list>()
+                ?.let { list ->
+                    list.item_key = null
+                    store.put(list)
+                }
+        }
     }
 
     override suspend fun removeUserData(transaction: Transaction, id: String) {
-        TODO("Not yet implemented")
+        transaction.store { store ->
+            store.get(Key(id))
+                ?.unsafeCast<Item_list>()
+                ?.let { list ->
+                    list.user_info = null
+                    list.user_previous_key = null
+                    list.user_current_key = null
+                    list.user_next_key = null
+                    store.put(list)
+                }
+        }
     }
 
     override suspend fun get(transaction: Transaction, id: String): ItemListEntry? {
-        TODO("Not yet implemented")
+        return transaction.store { store ->
+            store.get(Key(id))
+                ?.unsafeCast<Item_list>()
+                ?.toDomain()
+        }
     }
 
     override suspend fun getIds(transaction: Transaction, itemType: String, itemKey: String): List<String> {
-        TODO("Not yet implemented")
+        return transaction.store { store ->
+            store.index("item_list_item_type_item_key").openKeyCursor(
+                // item_type = itemType && item_key = itemKey
+                Key(only(arrayOf(itemType, itemKey)))
+            ).map { cursor ->
+                cursor.primaryKey.unsafeCast<String>()
+            }.toList()
+        }
     }
 
     override suspend fun getInvalidatedItemIds(
@@ -59,27 +130,77 @@ internal class KottageIndexeddbItemListRepository : KottageItemListRepository {
         beforeExpireAt: Long?,
         limit: Long
     ): List<String> {
-        TODO("Not yet implemented")
+        return transaction.store { store ->
+            (if (beforeExpireAt != null) {
+                store.index("item_list_type_expire_at").openCursor(
+                    // type = type && expire_at < beforeExpireAt
+                    bound(
+                        arrayOf(type),
+                        arrayOf(type, beforeExpireAt),
+                        upperOpen = true
+                    )
+                )
+            } else {
+                store.index("item_list_type_expire_at").openCursor(
+                    // type = type
+                    bound(
+                        arrayOf(type),
+                        arrayOf(type, emptyArray<Any>())
+                    )
+                )
+            }).map { cursor ->
+                cursor.value.unsafeCast<Item_list>()
+            }.filter {
+                (it.item_key == null)
+            }.take(limit).map { it.id }.toList()
+        }
     }
 
     override suspend fun getCount(transaction: Transaction, type: String): Long {
-        TODO("Not yet implemented")
+        return transaction.store { store ->
+            store.index("item_list_item_type").count(
+                Key(type)
+            ).toLong()
+        }
     }
 
     override suspend fun getInvalidatedItemCount(transaction: Transaction, type: String): Long {
-        TODO("Not yet implemented")
+        return transaction.store { store ->
+            store.index("item_list_item_type").openCursor(
+                Key(type)
+            ).count { cursor ->
+                (cursor.value.unsafeCast<Item_list>().item_key == null)
+            }.toLong()
+        }
     }
 
     override suspend fun getAllTypes(transaction: Transaction, receiver: suspend (type: String) -> Unit) {
-        TODO("Not yet implemented")
+        transaction.statsStore { store ->
+            store.openKeyCursor().collect { cursor ->
+                val itemListType = cursor.primaryKey.unsafeCast<String>()
+                receiver(itemListType)
+            }
+        }
     }
 
     override suspend fun delete(transaction: Transaction, id: String) {
-        TODO("Not yet implemented")
+        transaction.store { store ->
+            store.delete(Key(id))
+        }
     }
 
     override suspend fun deleteAll(transaction: Transaction, type: String) {
-        TODO("Not yet implemented")
+        transaction.store { store ->
+            store.index("item_list_type_expire_at").openCursor(
+                // type = type
+                bound(
+                    arrayOf(type),
+                    arrayOf(type, emptyArray<Any>())
+                )
+            ).collect { cursor ->
+                cursor.delete()
+            }
+        }
     }
 
     override suspend fun createStats(
@@ -89,42 +210,89 @@ internal class KottageIndexeddbItemListRepository : KottageItemListRepository {
         firstItemListEntryId: String,
         lastItemListEntryId: String
     ) {
-        TODO("Not yet implemented")
+        transaction.statsStore { store ->
+            store.add(jso<Item_list_stats> {
+                item_list_type = type
+                this.count = count
+                first_item_list_id = firstItemListEntryId
+                last_item_list_id = lastItemListEntryId
+            })
+        }
     }
 
     override suspend fun getStats(transaction: Transaction, type: String): ItemListStats? {
-        TODO("Not yet implemented")
+        return transaction.statsStore { store ->
+            store.get(Key(type))?.unsafeCast<Item_list_stats>()?.toDomain()
+        }
     }
 
     override suspend fun getStatsCount(transaction: Transaction, type: String): Long {
-        TODO("Not yet implemented")
+        return transaction.statsStore { store ->
+            store.get(Key(type))?.unsafeCast<Item_list_stats>()?.count ?: 0L
+        }
     }
 
     override suspend fun incrementStatsCount(transaction: Transaction, type: String, count: Long) {
-        TODO("Not yet implemented")
+        transaction.statsStore { store ->
+            store.get(Key(type))
+                ?.unsafeCast<Item_list_stats>()?.let { stats ->
+                    stats.count += count
+                    store.put(stats)
+                }
+        }
     }
 
     override suspend fun decrementStatsCount(transaction: Transaction, type: String, count: Long) {
-        TODO("Not yet implemented")
+        transaction.statsStore { store ->
+            store.get(Key(type))
+                ?.unsafeCast<Item_list_stats>()?.let { stats ->
+                    stats.count -= count
+                    store.put(stats)
+                }
+        }
     }
 
     override suspend fun updateStatsCount(transaction: Transaction, type: String, count: Long) {
-        TODO("Not yet implemented")
+        transaction.statsStore { store ->
+            store.get(Key(type))
+                ?.unsafeCast<Item_list_stats>()?.let { stats ->
+                    stats.count = count
+                    store.put(stats)
+                }
+        }
     }
 
     override suspend fun updateStatsFirstItem(transaction: Transaction, type: String, id: String) {
-        TODO("Not yet implemented")
+        transaction.statsStore { store ->
+            store.get(Key(type))
+                ?.unsafeCast<Item_list_stats>()?.let { stats ->
+                    stats.first_item_list_id = id
+                    store.put(stats)
+                }
+        }
     }
 
     override suspend fun updateStatsLastItem(transaction: Transaction, type: String, id: String) {
-        TODO("Not yet implemented")
+        transaction.statsStore { store ->
+            store.get(Key(type))
+                ?.unsafeCast<Item_list_stats>()?.let { stats ->
+                    stats.last_item_list_id = id
+                    store.put(stats)
+                }
+        }
     }
 
     override suspend fun deleteStats(transaction: Transaction, type: String) {
-        TODO("Not yet implemented")
+        transaction.statsStore { store ->
+            store.delete(Key(type))
+        }
     }
 
     private inline fun <R> Transaction.store(block: WriteTransaction.(store: ObjectStore) -> R): R {
         return with(transaction) { block(transaction.objectStore("item_list")) }
+    }
+
+    private inline fun <R> Transaction.statsStore(block: WriteTransaction.(store: ObjectStore) -> R): R {
+        return with(transaction) { block(transaction.objectStore("item_list_stats")) }
     }
 }

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemListRepository.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemListRepository.kt
@@ -1,0 +1,111 @@
+package io.github.irgaly.kottage.internal.repository
+
+import io.github.irgaly.kottage.internal.model.ItemListEntry
+import io.github.irgaly.kottage.internal.model.ItemListStats
+
+internal class KottageIndexeddbItemListRepository : KottageItemListRepository {
+    override fun upsert(entry: ItemListEntry) {
+        TODO("Not yet implemented")
+    }
+
+    override fun updatePreviousId(id: String, previousId: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun updateNextId(id: String, nextId: String?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun updateItemKey(id: String, itemType: String, itemKey: String?, expireAt: Long?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun updateExpireAt(id: String, expireAt: Long?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun removeItemKey(id: String) {
+        TODO("Not yet implemented")
+    }
+
+    override fun removeUserData(id: String) {
+        TODO("Not yet implemented")
+    }
+
+    override fun get(id: String): ItemListEntry? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getIds(itemType: String, itemKey: String): List<String> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getInvalidatedItemIds(
+        type: String,
+        beforeExpireAt: Long?,
+        limit: Long
+    ): List<String> {
+        TODO("Not yet implemented")
+    }
+
+    override fun getCount(type: String): Long {
+        TODO("Not yet implemented")
+    }
+
+    override fun getInvalidatedItemCount(type: String): Long {
+        TODO("Not yet implemented")
+    }
+
+    override fun getAllTypes(receiver: (type: String) -> Unit) {
+        TODO("Not yet implemented")
+    }
+
+    override fun delete(id: String) {
+        TODO("Not yet implemented")
+    }
+
+    override fun deleteAll(type: String) {
+        TODO("Not yet implemented")
+    }
+
+    override fun createStats(
+        type: String,
+        count: Long,
+        firstItemListEntryId: String,
+        lastItemListEntryId: String
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getStats(type: String): ItemListStats? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getStatsCount(type: String): Long {
+        TODO("Not yet implemented")
+    }
+
+    override fun incrementStatsCount(type: String, count: Long) {
+        TODO("Not yet implemented")
+    }
+
+    override fun decrementStatsCount(type: String, count: Long) {
+        TODO("Not yet implemented")
+    }
+
+    override fun updateStatsCount(type: String, count: Long) {
+        TODO("Not yet implemented")
+    }
+
+    override fun updateStatsFirstItem(type: String, id: String) {
+        TODO("Not yet implemented")
+    }
+
+    override fun updateStatsLastItem(type: String, id: String) {
+        TODO("Not yet implemented")
+    }
+
+    override fun deleteStats(type: String) {
+        TODO("Not yet implemented")
+    }
+}

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemListRepository.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemListRepository.kt
@@ -2,19 +2,20 @@ package io.github.irgaly.kottage.internal.repository
 
 import com.juul.indexeddb.ObjectStore
 import com.juul.indexeddb.WriteTransaction
-import io.github.irgaly.kottage.data.indexeddb.KottageIndexeddbDatabase
 import io.github.irgaly.kottage.internal.database.Transaction
 import io.github.irgaly.kottage.internal.model.ItemListEntry
 import io.github.irgaly.kottage.internal.model.ItemListStats
 
-internal class KottageIndexeddbItemListRepository(
-    private val database: KottageIndexeddbDatabase
-) : KottageItemListRepository {
+internal class KottageIndexeddbItemListRepository : KottageItemListRepository {
     override suspend fun upsert(transaction: Transaction, entry: ItemListEntry) {
         TODO("Not yet implemented")
     }
 
-    override suspend fun updatePreviousId(transaction: Transaction, id: String, previousId: String?) {
+    override suspend fun updatePreviousId(
+        transaction: Transaction,
+        id: String,
+        previousId: String?
+    ) {
         TODO("Not yet implemented")
     }
 

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemListRepository.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemListRepository.kt
@@ -5,19 +5,19 @@ import io.github.irgaly.kottage.internal.model.ItemListEntry
 import io.github.irgaly.kottage.internal.model.ItemListStats
 
 internal class KottageIndexeddbItemListRepository : KottageItemListRepository {
-    override fun upsert(transaction: Transaction, entry: ItemListEntry) {
+    override suspend fun upsert(transaction: Transaction, entry: ItemListEntry) {
         TODO("Not yet implemented")
     }
 
-    override fun updatePreviousId(transaction: Transaction, id: String, previousId: String?) {
+    override suspend fun updatePreviousId(transaction: Transaction, id: String, previousId: String?) {
         TODO("Not yet implemented")
     }
 
-    override fun updateNextId(transaction: Transaction, id: String, nextId: String?) {
+    override suspend fun updateNextId(transaction: Transaction, id: String, nextId: String?) {
         TODO("Not yet implemented")
     }
 
-    override fun updateItemKey(
+    override suspend fun updateItemKey(
         transaction: Transaction,
         id: String,
         itemType: String,
@@ -27,27 +27,27 @@ internal class KottageIndexeddbItemListRepository : KottageItemListRepository {
         TODO("Not yet implemented")
     }
 
-    override fun updateExpireAt(transaction: Transaction, id: String, expireAt: Long?) {
+    override suspend fun updateExpireAt(transaction: Transaction, id: String, expireAt: Long?) {
         TODO("Not yet implemented")
     }
 
-    override fun removeItemKey(transaction: Transaction, id: String) {
+    override suspend fun removeItemKey(transaction: Transaction, id: String) {
         TODO("Not yet implemented")
     }
 
-    override fun removeUserData(transaction: Transaction, id: String) {
+    override suspend fun removeUserData(transaction: Transaction, id: String) {
         TODO("Not yet implemented")
     }
 
-    override fun get(transaction: Transaction, id: String): ItemListEntry? {
+    override suspend fun get(transaction: Transaction, id: String): ItemListEntry? {
         TODO("Not yet implemented")
     }
 
-    override fun getIds(transaction: Transaction, itemType: String, itemKey: String): List<String> {
+    override suspend fun getIds(transaction: Transaction, itemType: String, itemKey: String): List<String> {
         TODO("Not yet implemented")
     }
 
-    override fun getInvalidatedItemIds(
+    override suspend fun getInvalidatedItemIds(
         transaction: Transaction,
         type: String,
         beforeExpireAt: Long?,
@@ -56,27 +56,27 @@ internal class KottageIndexeddbItemListRepository : KottageItemListRepository {
         TODO("Not yet implemented")
     }
 
-    override fun getCount(transaction: Transaction, type: String): Long {
+    override suspend fun getCount(transaction: Transaction, type: String): Long {
         TODO("Not yet implemented")
     }
 
-    override fun getInvalidatedItemCount(transaction: Transaction, type: String): Long {
+    override suspend fun getInvalidatedItemCount(transaction: Transaction, type: String): Long {
         TODO("Not yet implemented")
     }
 
-    override fun getAllTypes(transaction: Transaction, receiver: (type: String) -> Unit) {
+    override suspend fun getAllTypes(transaction: Transaction, receiver: suspend (type: String) -> Unit) {
         TODO("Not yet implemented")
     }
 
-    override fun delete(transaction: Transaction, id: String) {
+    override suspend fun delete(transaction: Transaction, id: String) {
         TODO("Not yet implemented")
     }
 
-    override fun deleteAll(transaction: Transaction, type: String) {
+    override suspend fun deleteAll(transaction: Transaction, type: String) {
         TODO("Not yet implemented")
     }
 
-    override fun createStats(
+    override suspend fun createStats(
         transaction: Transaction,
         type: String,
         count: Long,
@@ -86,35 +86,35 @@ internal class KottageIndexeddbItemListRepository : KottageItemListRepository {
         TODO("Not yet implemented")
     }
 
-    override fun getStats(transaction: Transaction, type: String): ItemListStats? {
+    override suspend fun getStats(transaction: Transaction, type: String): ItemListStats? {
         TODO("Not yet implemented")
     }
 
-    override fun getStatsCount(transaction: Transaction, type: String): Long {
+    override suspend fun getStatsCount(transaction: Transaction, type: String): Long {
         TODO("Not yet implemented")
     }
 
-    override fun incrementStatsCount(transaction: Transaction, type: String, count: Long) {
+    override suspend fun incrementStatsCount(transaction: Transaction, type: String, count: Long) {
         TODO("Not yet implemented")
     }
 
-    override fun decrementStatsCount(transaction: Transaction, type: String, count: Long) {
+    override suspend fun decrementStatsCount(transaction: Transaction, type: String, count: Long) {
         TODO("Not yet implemented")
     }
 
-    override fun updateStatsCount(transaction: Transaction, type: String, count: Long) {
+    override suspend fun updateStatsCount(transaction: Transaction, type: String, count: Long) {
         TODO("Not yet implemented")
     }
 
-    override fun updateStatsFirstItem(transaction: Transaction, type: String, id: String) {
+    override suspend fun updateStatsFirstItem(transaction: Transaction, type: String, id: String) {
         TODO("Not yet implemented")
     }
 
-    override fun updateStatsLastItem(transaction: Transaction, type: String, id: String) {
+    override suspend fun updateStatsLastItem(transaction: Transaction, type: String, id: String) {
         TODO("Not yet implemented")
     }
 
-    override fun deleteStats(transaction: Transaction, type: String) {
+    override suspend fun deleteStats(transaction: Transaction, type: String) {
         TODO("Not yet implemented")
     }
 }

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemRepository.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemRepository.kt
@@ -217,7 +217,7 @@ internal class KottageIndexeddbItemRepository : KottageItemRepository {
     ) {
         transaction.statsStore { store ->
             val stats = getOrCreate(store, itemType)
-            stats.count += 1
+            stats.count += count
             store.put(stats)
         }
     }
@@ -229,7 +229,7 @@ internal class KottageIndexeddbItemRepository : KottageItemRepository {
     ) {
         transaction.statsStore { store ->
             val stats = getOrCreate(store, itemType)
-            stats.count -= 1
+            stats.count -= count
             store.put(stats)
         }
     }

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemRepository.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemRepository.kt
@@ -33,7 +33,7 @@ internal class KottageIndexeddbItemRepository : KottageItemRepository {
             store.get(Key(Item.toEntityKey(key, itemType)))
                 ?.unsafeCast<io.github.irgaly.kottage.data.indexeddb.schema.entity.Item>()
                 ?.let { item ->
-                    item.last_read_at = lastReadAt
+                    item.last_read_at = lastReadAt.toDouble()
                     store.put(item)
                 }
         }
@@ -49,7 +49,7 @@ internal class KottageIndexeddbItemRepository : KottageItemRepository {
             store.get(Key(Item.toEntityKey(key, itemType)))
                 ?.unsafeCast<io.github.irgaly.kottage.data.indexeddb.schema.entity.Item>()
                 ?.let { item ->
-                    item.expire_at = expireAt
+                    item.expire_at = expireAt.toDouble()
                     store.put(item)
                 }
         }
@@ -105,7 +105,7 @@ internal class KottageIndexeddbItemRepository : KottageItemRepository {
                     // type = itemType && created_at <= now
                     bound(
                         arrayOf(itemType),
-                        arrayOf(itemType, now)
+                        arrayOf(itemType, now.toDouble())
                     )
                 ).collect { cursor ->
                     val key = cursor.primaryKey.unsafeCast<String>()
@@ -114,7 +114,7 @@ internal class KottageIndexeddbItemRepository : KottageItemRepository {
             } else {
                 store.index("item_expire_at").openCursor(
                     // created_at <= now
-                    upperBound(now)
+                    upperBound(now.toDouble())
                 ).collect { cursor ->
                     val item =
                         cursor.value.unsafeCast<io.github.irgaly.kottage.data.indexeddb.schema.entity.Item>()
@@ -180,7 +180,7 @@ internal class KottageIndexeddbItemRepository : KottageItemRepository {
             store.openCursor().map { cursor ->
                 cursor.value.unsafeCast<Item_stats>()
             }.filter { stats ->
-                ((stats.count <= 0) && (stats.event_count <= 0))
+                ((stats.count.toLong() <= 0L) && (stats.event_count.toLong() <= 0))
             }.take(limit).map {
                 it.toDomain()
             }.toList()
@@ -206,7 +206,7 @@ internal class KottageIndexeddbItemRepository : KottageItemRepository {
 
     override suspend fun getStatsCount(transaction: Transaction, itemType: String): Long {
         return transaction.statsStore { store ->
-            store.get(Key(itemType))?.unsafeCast<Item_stats>()?.count ?: 0
+            store.get(Key(itemType))?.unsafeCast<Item_stats>()?.count?.toLong() ?: 0
         }
     }
 
@@ -217,7 +217,7 @@ internal class KottageIndexeddbItemRepository : KottageItemRepository {
     ) {
         transaction.statsStore { store ->
             val stats = getOrCreate(store, itemType)
-            stats.count += count
+            stats.count += count.toDouble()
             store.put(stats)
         }
     }
@@ -229,7 +229,7 @@ internal class KottageIndexeddbItemRepository : KottageItemRepository {
     ) {
         transaction.statsStore { store ->
             val stats = getOrCreate(store, itemType)
-            stats.count -= count
+            stats.count -= count.toDouble()
             store.put(stats)
         }
     }
@@ -237,7 +237,7 @@ internal class KottageIndexeddbItemRepository : KottageItemRepository {
     override suspend fun updateStatsCount(transaction: Transaction, itemType: String, count: Long) {
         transaction.statsStore { store ->
             val stats = getOrCreate(store, itemType)
-            stats.count = count
+            stats.count = count.toDouble()
             store.put(stats)
         }
     }
@@ -256,8 +256,8 @@ internal class KottageIndexeddbItemRepository : KottageItemRepository {
         if (stats == null) {
             stats = jso {
                 item_type = itemType
-                count = 0
-                event_count = 0
+                count = 0L.toDouble()
+                event_count = 0L.toDouble()
             }
             store.add(stats)
         }

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemRepository.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemRepository.kt
@@ -1,38 +1,54 @@
 package io.github.irgaly.kottage.internal.repository
 
+import io.github.irgaly.kottage.internal.database.Transaction
 import io.github.irgaly.kottage.internal.model.Item
 import io.github.irgaly.kottage.internal.model.ItemStats
 
 internal class KottageIndexeddbItemRepository : KottageItemRepository {
-    override fun upsert(item: Item) {
+    override fun upsert(transaction: Transaction, item: Item) {
         TODO("Not yet implemented")
     }
 
-    override fun updateLastRead(key: String, itemType: String, lastReadAt: Long) {
+    override fun updateLastRead(
+        transaction: Transaction,
+        key: String,
+        itemType: String,
+        lastReadAt: Long
+    ) {
         TODO("Not yet implemented")
     }
 
-    override fun updateExpireAt(key: String, itemType: String, expireAt: Long) {
+    override fun updateExpireAt(
+        transaction: Transaction,
+        key: String,
+        itemType: String,
+        expireAt: Long
+    ) {
         TODO("Not yet implemented")
     }
 
-    override fun exists(key: String, itemType: String): Boolean {
+    override fun exists(transaction: Transaction, key: String, itemType: String): Boolean {
         TODO("Not yet implemented")
     }
 
-    override fun get(key: String, itemType: String): Item? {
+    override fun get(transaction: Transaction, key: String, itemType: String): Item? {
         TODO("Not yet implemented")
     }
 
-    override fun getCount(itemType: String): Long {
+    override fun getCount(transaction: Transaction, itemType: String): Long {
         TODO("Not yet implemented")
     }
 
-    override fun getAllKeys(itemType: String, receiver: (key: String) -> Unit) {
+    override fun getAllKeys(
+        transaction: Transaction,
+        itemType: String,
+        receiver: (key: String) -> Unit
+    ) {
         TODO("Not yet implemented")
     }
 
     override fun getExpiredKeys(
+        transaction: Transaction,
         now: Long,
         itemType: String?,
         receiver: (key: String, itemType: String) -> Unit
@@ -41,6 +57,7 @@ internal class KottageIndexeddbItemRepository : KottageItemRepository {
     }
 
     override fun getLeastRecentlyUsedKeys(
+        transaction: Transaction,
         itemType: String,
         limit: Long?,
         receiver: (key: String) -> Boolean
@@ -48,43 +65,48 @@ internal class KottageIndexeddbItemRepository : KottageItemRepository {
         TODO("Not yet implemented")
     }
 
-    override fun getOlderKeys(itemType: String, limit: Long?, receiver: (key: String) -> Boolean) {
+    override fun getOlderKeys(
+        transaction: Transaction,
+        itemType: String,
+        limit: Long?,
+        receiver: (key: String) -> Boolean
+    ) {
         TODO("Not yet implemented")
     }
 
-    override fun getStats(itemType: String): ItemStats? {
+    override fun getStats(transaction: Transaction, itemType: String): ItemStats? {
         TODO("Not yet implemented")
     }
 
-    override fun getEmptyStats(limit: Long): List<ItemStats> {
+    override fun getEmptyStats(transaction: Transaction, limit: Long): List<ItemStats> {
         TODO("Not yet implemented")
     }
 
-    override fun delete(key: String, itemType: String) {
+    override fun delete(transaction: Transaction, key: String, itemType: String) {
         TODO("Not yet implemented")
     }
 
-    override fun deleteAll(itemType: String) {
+    override fun deleteAll(transaction: Transaction, itemType: String) {
         TODO("Not yet implemented")
     }
 
-    override fun getStatsCount(itemType: String): Long {
+    override fun getStatsCount(transaction: Transaction, itemType: String): Long {
         TODO("Not yet implemented")
     }
 
-    override fun incrementStatsCount(itemType: String, count: Long) {
+    override fun incrementStatsCount(transaction: Transaction, itemType: String, count: Long) {
         TODO("Not yet implemented")
     }
 
-    override fun decrementStatsCount(itemType: String, count: Long) {
+    override fun decrementStatsCount(transaction: Transaction, itemType: String, count: Long) {
         TODO("Not yet implemented")
     }
 
-    override fun updateStatsCount(itemType: String, count: Long) {
+    override fun updateStatsCount(transaction: Transaction, itemType: String, count: Long) {
         TODO("Not yet implemented")
     }
 
-    override fun deleteStats(itemType: String) {
+    override fun deleteStats(transaction: Transaction, itemType: String) {
         TODO("Not yet implemented")
     }
 }

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemRepository.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemRepository.kt
@@ -83,7 +83,7 @@ internal class KottageIndexeddbItemRepository : KottageItemRepository {
     ) {
         transaction.store { store ->
             store.index("item_type_created_at")
-                .iterateWithChunk<io.github.irgaly.kottage.data.indexeddb.schema.entity.Item, Double>(
+                .iterateWithChunk<io.github.irgaly.kottage.data.indexeddb.schema.entity.Item, String, Double>(
                     this,
                     chunkSize = 100L,
                     primaryKey = { it.key },
@@ -115,7 +115,7 @@ internal class KottageIndexeddbItemRepository : KottageItemRepository {
         transaction.store { store ->
             if (itemType != null) {
                 store.index("item_type_expire_at")
-                    .iterateWithChunk<io.github.irgaly.kottage.data.indexeddb.schema.entity.Item, Double>(
+                    .iterateWithChunk<io.github.irgaly.kottage.data.indexeddb.schema.entity.Item, String, Double>(
                         this,
                         chunkSize = 100L,
                         primaryKey = { it.key },
@@ -137,7 +137,7 @@ internal class KottageIndexeddbItemRepository : KottageItemRepository {
                     }
             } else {
                 store.index("item_expire_at")
-                    .iterateWithChunk<io.github.irgaly.kottage.data.indexeddb.schema.entity.Item, Double>(
+                    .iterateWithChunk<io.github.irgaly.kottage.data.indexeddb.schema.entity.Item, String, Double>(
                         this,
                         chunkSize = 100L,
                         primaryKey = { it.key },
@@ -165,7 +165,7 @@ internal class KottageIndexeddbItemRepository : KottageItemRepository {
     ) {
         transaction.store { store ->
             store.index("item_type_last_read_at")
-                .iterateWithChunk<io.github.irgaly.kottage.data.indexeddb.schema.entity.Item, Double>(
+                .iterateWithChunk<io.github.irgaly.kottage.data.indexeddb.schema.entity.Item, String, Double>(
                     this,
                     chunkSize = 100L,
                     primaryKey = { it.key },
@@ -196,7 +196,7 @@ internal class KottageIndexeddbItemRepository : KottageItemRepository {
     ) {
         transaction.store { store ->
             store.index("item_type_created_at")
-                .iterateWithChunk<io.github.irgaly.kottage.data.indexeddb.schema.entity.Item, Double>(
+                .iterateWithChunk<io.github.irgaly.kottage.data.indexeddb.schema.entity.Item, String, Double>(
                     this,
                     chunkSize = 100L,
                     primaryKey = { it.key },

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemRepository.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemRepository.kt
@@ -1,12 +1,9 @@
 package io.github.irgaly.kottage.internal.repository
 
 import io.github.irgaly.kottage.internal.model.Item
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
+import io.github.irgaly.kottage.internal.model.ItemStats
 
-internal class KottageIndexeddbItemRepository(
-    private val dispatcher: CoroutineDispatcher = Dispatchers.Default
-) : KottageItemRepository {
+internal class KottageIndexeddbItemRepository : KottageItemRepository {
     override fun upsert(item: Item) {
         TODO("Not yet implemented")
     }
@@ -43,15 +40,27 @@ internal class KottageIndexeddbItemRepository(
         TODO("Not yet implemented")
     }
 
+    override fun getLeastRecentlyUsedKeys(
+        itemType: String,
+        limit: Long?,
+        receiver: (key: String) -> Boolean
+    ) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getOlderKeys(itemType: String, limit: Long?, receiver: (key: String) -> Boolean) {
+        TODO("Not yet implemented")
+    }
+
+    override fun getStats(itemType: String): ItemStats? {
+        TODO("Not yet implemented")
+    }
+
+    override fun getEmptyStats(limit: Long): List<ItemStats> {
+        TODO("Not yet implemented")
+    }
+
     override fun delete(key: String, itemType: String) {
-        TODO("Not yet implemented")
-    }
-
-    override fun deleteLeastRecentlyUsed(itemType: String, limit: Long) {
-        TODO("Not yet implemented")
-    }
-
-    override fun deleteOlderItems(itemType: String, limit: Long) {
         TODO("Not yet implemented")
     }
 

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemRepository.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemRepository.kt
@@ -5,11 +5,11 @@ import io.github.irgaly.kottage.internal.model.Item
 import io.github.irgaly.kottage.internal.model.ItemStats
 
 internal class KottageIndexeddbItemRepository : KottageItemRepository {
-    override fun upsert(transaction: Transaction, item: Item) {
+    override suspend fun upsert(transaction: Transaction, item: Item) {
         TODO("Not yet implemented")
     }
 
-    override fun updateLastRead(
+    override suspend fun updateLastRead(
         transaction: Transaction,
         key: String,
         itemType: String,
@@ -18,7 +18,7 @@ internal class KottageIndexeddbItemRepository : KottageItemRepository {
         TODO("Not yet implemented")
     }
 
-    override fun updateExpireAt(
+    override suspend fun updateExpireAt(
         transaction: Transaction,
         key: String,
         itemType: String,
@@ -27,86 +27,86 @@ internal class KottageIndexeddbItemRepository : KottageItemRepository {
         TODO("Not yet implemented")
     }
 
-    override fun exists(transaction: Transaction, key: String, itemType: String): Boolean {
+    override suspend fun exists(transaction: Transaction, key: String, itemType: String): Boolean {
         TODO("Not yet implemented")
     }
 
-    override fun get(transaction: Transaction, key: String, itemType: String): Item? {
+    override suspend fun get(transaction: Transaction, key: String, itemType: String): Item? {
         TODO("Not yet implemented")
     }
 
-    override fun getCount(transaction: Transaction, itemType: String): Long {
+    override suspend fun getCount(transaction: Transaction, itemType: String): Long {
         TODO("Not yet implemented")
     }
 
-    override fun getAllKeys(
+    override suspend fun getAllKeys(
         transaction: Transaction,
         itemType: String,
-        receiver: (key: String) -> Unit
+        receiver: suspend (key: String) -> Unit
     ) {
         TODO("Not yet implemented")
     }
 
-    override fun getExpiredKeys(
+    override suspend fun getExpiredKeys(
         transaction: Transaction,
         now: Long,
         itemType: String?,
-        receiver: (key: String, itemType: String) -> Unit
+        receiver: suspend (key: String, itemType: String) -> Unit
     ) {
         TODO("Not yet implemented")
     }
 
-    override fun getLeastRecentlyUsedKeys(
+    override suspend fun getLeastRecentlyUsedKeys(
         transaction: Transaction,
         itemType: String,
         limit: Long?,
-        receiver: (key: String) -> Boolean
+        receiver: suspend (key: String) -> Boolean
     ) {
         TODO("Not yet implemented")
     }
 
-    override fun getOlderKeys(
+    override suspend fun getOlderKeys(
         transaction: Transaction,
         itemType: String,
         limit: Long?,
-        receiver: (key: String) -> Boolean
+        receiver: suspend (key: String) -> Boolean
     ) {
         TODO("Not yet implemented")
     }
 
-    override fun getStats(transaction: Transaction, itemType: String): ItemStats? {
+    override suspend fun getStats(transaction: Transaction, itemType: String): ItemStats? {
         TODO("Not yet implemented")
     }
 
-    override fun getEmptyStats(transaction: Transaction, limit: Long): List<ItemStats> {
+    override suspend fun getEmptyStats(transaction: Transaction, limit: Long): List<ItemStats> {
         TODO("Not yet implemented")
     }
 
-    override fun delete(transaction: Transaction, key: String, itemType: String) {
+    override suspend fun delete(transaction: Transaction, key: String, itemType: String) {
         TODO("Not yet implemented")
     }
 
-    override fun deleteAll(transaction: Transaction, itemType: String) {
+    override suspend fun deleteAll(transaction: Transaction, itemType: String) {
         TODO("Not yet implemented")
     }
 
-    override fun getStatsCount(transaction: Transaction, itemType: String): Long {
+    override suspend fun getStatsCount(transaction: Transaction, itemType: String): Long {
         TODO("Not yet implemented")
     }
 
-    override fun incrementStatsCount(transaction: Transaction, itemType: String, count: Long) {
+    override suspend fun incrementStatsCount(transaction: Transaction, itemType: String, count: Long) {
         TODO("Not yet implemented")
     }
 
-    override fun decrementStatsCount(transaction: Transaction, itemType: String, count: Long) {
+    override suspend fun decrementStatsCount(transaction: Transaction, itemType: String, count: Long) {
         TODO("Not yet implemented")
     }
 
-    override fun updateStatsCount(transaction: Transaction, itemType: String, count: Long) {
+    override suspend fun updateStatsCount(transaction: Transaction, itemType: String, count: Long) {
         TODO("Not yet implemented")
     }
 
-    override fun deleteStats(transaction: Transaction, itemType: String) {
+    override suspend fun deleteStats(transaction: Transaction, itemType: String) {
         TODO("Not yet implemented")
     }
 }

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemRepository.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemRepository.kt
@@ -14,6 +14,7 @@ import io.github.irgaly.kottage.internal.model.Item
 import io.github.irgaly.kottage.internal.model.ItemStats
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.flow.toList
 
 internal class KottageIndexeddbItemRepository : KottageItemRepository {
@@ -131,6 +132,7 @@ internal class KottageIndexeddbItemRepository : KottageItemRepository {
         receiver: suspend (key: String) -> Boolean
     ) {
         transaction.store { store ->
+            var takeNext = true
             store.index("item_type_last_read_at").openKeyCursor(
                 // type = itemType
                 bound(
@@ -139,9 +141,9 @@ internal class KottageIndexeddbItemRepository : KottageItemRepository {
                 )
             ).let {
                 if (limit != null) it.take(limit) else it
-            }.collect { cursor ->
+            }.takeWhile { takeNext }.collect { cursor ->
                 val key = cursor.primaryKey.unsafeCast<String>()
-                receiver(Item.keyFromEntityKey(key, itemType))
+                takeNext = receiver(Item.keyFromEntityKey(key, itemType))
             }
         }
     }
@@ -153,6 +155,7 @@ internal class KottageIndexeddbItemRepository : KottageItemRepository {
         receiver: suspend (key: String) -> Boolean
     ) {
         transaction.store { store ->
+            var takeNext = true
             store.index("item_type_created_at").openKeyCursor(
                 // type = itemType
                 bound(
@@ -161,9 +164,9 @@ internal class KottageIndexeddbItemRepository : KottageItemRepository {
                 )
             ).let {
                 if (limit != null) it.take(limit) else it
-            }.collect { cursor ->
+            }.takeWhile { takeNext }.collect { cursor ->
                 val key = cursor.primaryKey.unsafeCast<String>()
-                receiver(Item.keyFromEntityKey(key, itemType))
+                takeNext = receiver(Item.keyFromEntityKey(key, itemType))
             }
         }
     }

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemRepository.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemRepository.kt
@@ -1,12 +1,37 @@
 package io.github.irgaly.kottage.internal.repository
 
+import com.juul.indexeddb.Key
+import com.juul.indexeddb.ObjectStore
+import com.juul.indexeddb.WriteTransaction
+import com.juul.indexeddb.bound
+import com.juul.indexeddb.upperBound
+import io.github.irgaly.kottage.data.indexeddb.KottageIndexeddbDatabase
+import io.github.irgaly.kottage.data.indexeddb.extension.exists
+import io.github.irgaly.kottage.data.indexeddb.extension.jso
+import io.github.irgaly.kottage.data.indexeddb.schema.entity.Item_stats
 import io.github.irgaly.kottage.internal.database.Transaction
 import io.github.irgaly.kottage.internal.model.Item
 import io.github.irgaly.kottage.internal.model.ItemStats
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.takeWhile
+import kotlinx.coroutines.flow.toList
 
-internal class KottageIndexeddbItemRepository : KottageItemRepository {
+/**
+ * Note:
+ * * indexeddb comparison
+ *     * https://stackoverflow.com/a/15625231/13403244
+ *     * https://w3c.github.io/IndexedDB/#key-construct
+ *     * null は index に含まれない
+ */
+internal class KottageIndexeddbItemRepository(
+    private val database: KottageIndexeddbDatabase
+) : KottageItemRepository {
     override suspend fun upsert(transaction: Transaction, item: Item) {
-        TODO("Not yet implemented")
+        transaction.store { store ->
+            store.put(item.toEntity())
+        }
     }
 
     override suspend fun updateLastRead(
@@ -15,7 +40,14 @@ internal class KottageIndexeddbItemRepository : KottageItemRepository {
         itemType: String,
         lastReadAt: Long
     ) {
-        TODO("Not yet implemented")
+        transaction.store { store ->
+            store.get(Key(Item.toEntityKey(key, itemType)))
+                ?.unsafeCast<io.github.irgaly.kottage.data.indexeddb.schema.entity.Item>()
+                ?.let { item ->
+                    item.last_read_at = lastReadAt
+                    store.put(item)
+                }
+        }
     }
 
     override suspend fun updateExpireAt(
@@ -24,19 +56,34 @@ internal class KottageIndexeddbItemRepository : KottageItemRepository {
         itemType: String,
         expireAt: Long
     ) {
-        TODO("Not yet implemented")
+        transaction.store { store ->
+            store.get(Key(Item.toEntityKey(key, itemType)))
+                ?.unsafeCast<io.github.irgaly.kottage.data.indexeddb.schema.entity.Item>()
+                ?.let { item ->
+                    item.expire_at = expireAt
+                    store.put(item)
+                }
+        }
     }
 
     override suspend fun exists(transaction: Transaction, key: String, itemType: String): Boolean {
-        TODO("Not yet implemented")
+        return transaction.store { store ->
+            exists(store, Key(Item.toEntityKey(key, itemType)))
+        }
     }
 
     override suspend fun get(transaction: Transaction, key: String, itemType: String): Item? {
-        TODO("Not yet implemented")
+        return transaction.store { store ->
+            store.get(Key(Item.toEntityKey(key, itemType)))
+                ?.unsafeCast<io.github.irgaly.kottage.data.indexeddb.schema.entity.Item>()
+                ?.toDomain()
+        }
     }
 
     override suspend fun getCount(transaction: Transaction, itemType: String): Long {
-        TODO("Not yet implemented")
+        return transaction.store { store ->
+            store.index("item_type").count(Key(itemType)).toLong()
+        }
     }
 
     override suspend fun getAllKeys(
@@ -44,7 +91,17 @@ internal class KottageIndexeddbItemRepository : KottageItemRepository {
         itemType: String,
         receiver: suspend (key: String) -> Unit
     ) {
-        TODO("Not yet implemented")
+        transaction.store { store ->
+            store.index("item_type_created_at").openKeyCursor(
+                // type = itemType && created_at = Any
+                bound(
+                    arrayOf(itemType),
+                    arrayOf(itemType, emptyArray<Any>())
+                )
+            ).collect { cursor ->
+                receiver(cursor.primaryKey.unsafeCast<String>())
+            }
+        }
     }
 
     override suspend fun getExpiredKeys(
@@ -53,7 +110,29 @@ internal class KottageIndexeddbItemRepository : KottageItemRepository {
         itemType: String?,
         receiver: suspend (key: String, itemType: String) -> Unit
     ) {
-        TODO("Not yet implemented")
+        transaction.store { store ->
+            if (itemType != null) {
+                store.index("item_type_expire_at").openKeyCursor(
+                    // type = itemType && created_at <= now
+                    bound(
+                        arrayOf(itemType),
+                        arrayOf(itemType, now)
+                    )
+                ).collect { cursor ->
+                    val key = cursor.primaryKey.unsafeCast<String>()
+                    receiver(Item.keyFromEntityKey(key, itemType), itemType)
+                }
+            } else {
+                store.index("item_expire_at").openCursor(
+                    // created_at <= now
+                    upperBound(now)
+                ).collect { cursor ->
+                    val item =
+                        cursor.value.unsafeCast<io.github.irgaly.kottage.data.indexeddb.schema.entity.Item>()
+                    receiver(Item.keyFromEntityKey(item.key, item.type), item.type)
+                }
+            }
+        }
     }
 
     override suspend fun getLeastRecentlyUsedKeys(
@@ -62,7 +141,22 @@ internal class KottageIndexeddbItemRepository : KottageItemRepository {
         limit: Long?,
         receiver: suspend (key: String) -> Boolean
     ) {
-        TODO("Not yet implemented")
+        transaction.store { store ->
+            var consumed = 0L
+            store.index("item_type_last_read_at").openKeyCursor(
+                // type = itemType
+                bound(
+                    arrayOf(itemType),
+                    arrayOf(itemType, emptyArray<Any>())
+                )
+            ).takeWhile {
+                limit?.let { consumed < it } ?: true
+            }.collect { cursor ->
+                consumed++
+                val key = cursor.primaryKey.unsafeCast<String>()
+                receiver(Item.keyFromEntityKey(key, itemType))
+            }
+        }
     }
 
     override suspend fun getOlderKeys(
@@ -71,42 +165,128 @@ internal class KottageIndexeddbItemRepository : KottageItemRepository {
         limit: Long?,
         receiver: suspend (key: String) -> Boolean
     ) {
-        TODO("Not yet implemented")
+        transaction.store { store ->
+            var consumed = 0L
+            store.index("item_type_created_at").openKeyCursor(
+                // type = itemType
+                bound(
+                    arrayOf(itemType),
+                    arrayOf(itemType, emptyArray<Any>())
+                )
+            ).takeWhile {
+                limit?.let { consumed < it } ?: true
+            }.collect { cursor ->
+                consumed++
+                val key = cursor.primaryKey.unsafeCast<String>()
+                receiver(Item.keyFromEntityKey(key, itemType))
+            }
+        }
     }
 
     override suspend fun getStats(transaction: Transaction, itemType: String): ItemStats? {
-        TODO("Not yet implemented")
+        return transaction.statsStore { store ->
+            store.get(Key(itemType))?.unsafeCast<Item_stats>()?.toDomain()
+        }
     }
 
     override suspend fun getEmptyStats(transaction: Transaction, limit: Long): List<ItemStats> {
-        TODO("Not yet implemented")
+        return transaction.statsStore { store ->
+            // SQLite 側に合わせて index なしで総当たり処理
+            var consumed = 0L
+            store.openCursor().map { cursor ->
+                cursor.value.unsafeCast<Item_stats>().toDomain()
+            }.filter { stats ->
+                ((stats.count <= 0) && (stats.eventCount <= 0))
+            }.takeWhile {
+                (consumed < limit)
+            }.onEach {
+                consumed++
+            }.toList()
+        }
     }
 
     override suspend fun delete(transaction: Transaction, key: String, itemType: String) {
-        TODO("Not yet implemented")
+        transaction.store { store ->
+            store.delete(Key(Item.toEntityKey(key, itemType)))
+        }
     }
 
     override suspend fun deleteAll(transaction: Transaction, itemType: String) {
-        TODO("Not yet implemented")
+        transaction.store { store ->
+            store.index("item_type").openCursor(
+                // type = itemType
+                Key(itemType)
+            ).collect { cursor ->
+                cursor.delete()
+            }
+        }
     }
 
     override suspend fun getStatsCount(transaction: Transaction, itemType: String): Long {
-        TODO("Not yet implemented")
+        return transaction.statsStore { store ->
+            store.get(Key(itemType))?.unsafeCast<Item_stats>()?.toDomain()?.count ?: 0
+        }
     }
 
-    override suspend fun incrementStatsCount(transaction: Transaction, itemType: String, count: Long) {
-        TODO("Not yet implemented")
+    override suspend fun incrementStatsCount(
+        transaction: Transaction,
+        itemType: String,
+        count: Long
+    ) {
+        transaction.statsStore { store ->
+            val stats = getOrCreate(store, itemType)
+            stats.count += 1
+            store.put(stats)
+        }
     }
 
-    override suspend fun decrementStatsCount(transaction: Transaction, itemType: String, count: Long) {
-        TODO("Not yet implemented")
+    override suspend fun decrementStatsCount(
+        transaction: Transaction,
+        itemType: String,
+        count: Long
+    ) {
+        transaction.statsStore { store ->
+            val stats = getOrCreate(store, itemType)
+            stats.count -= 1
+            store.put(stats)
+        }
     }
 
     override suspend fun updateStatsCount(transaction: Transaction, itemType: String, count: Long) {
-        TODO("Not yet implemented")
+        transaction.statsStore { store ->
+            val stats = getOrCreate(store, itemType)
+            stats.count = count
+            store.put(stats)
+        }
     }
 
     override suspend fun deleteStats(transaction: Transaction, itemType: String) {
-        TODO("Not yet implemented")
+        transaction.statsStore { store ->
+            store.delete(Key(itemType))
+        }
+    }
+
+    private suspend fun WriteTransaction.getOrCreate(
+        store: ObjectStore,
+        itemType: String
+    ): Item_stats {
+        var stats = store.get(Key(itemType))?.unsafeCast<Item_stats>()
+        if (stats == null) {
+            stats = jso {
+                item_type = itemType
+                count = 0
+                event_count = 0
+            }
+            store.add(stats)
+        }
+        return stats
+    }
+
+    private inline fun <R> Transaction.store(block: WriteTransaction.(store: ObjectStore) -> R): R {
+        return with(transaction) { block(transaction.objectStore("item")) }
+    }
+
+    private inline fun <R> Transaction.statsStore(block: WriteTransaction.(store: ObjectStore) -> R): R {
+        return with(transaction) { block(transaction.objectStore("item_stats")) }
     }
 }

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbStatsRepository.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbStatsRepository.kt
@@ -2,10 +2,10 @@ package io.github.irgaly.kottage.internal.repository
 
 internal class KottageIndexeddbStatsRepository : KottageStatsRepository {
     override fun getLastEvictAt(): Long {
-        TODO()
+        TODO("Not yet implemented")
     }
 
     override fun updateLastEvictAt(now: Long) {
-        TODO()
+        TODO("Not yet implemented")
     }
 }

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbStatsRepository.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbStatsRepository.kt
@@ -3,14 +3,11 @@ package io.github.irgaly.kottage.internal.repository
 import com.juul.indexeddb.Key
 import com.juul.indexeddb.ObjectStore
 import com.juul.indexeddb.WriteTransaction
-import io.github.irgaly.kottage.data.indexeddb.KottageIndexeddbDatabase
 import io.github.irgaly.kottage.data.indexeddb.extension.jso
 import io.github.irgaly.kottage.data.indexeddb.schema.entity.Stats
 import io.github.irgaly.kottage.internal.database.Transaction
 
-internal class KottageIndexeddbStatsRepository(
-    private val database: KottageIndexeddbDatabase
-) : KottageStatsRepository {
+internal class KottageIndexeddbStatsRepository : KottageStatsRepository {
     private val key = "kottage"
 
     override suspend fun getLastEvictAt(transaction: Transaction): Long {

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbStatsRepository.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbStatsRepository.kt
@@ -12,14 +12,14 @@ internal class KottageIndexeddbStatsRepository : KottageStatsRepository {
 
     override suspend fun getLastEvictAt(transaction: Transaction): Long {
         return transaction.store { store ->
-            getOrCreate(store, key).last_evict_at
+            getOrCreate(store, key).last_evict_at.toLong()
         }
     }
 
     override suspend fun updateLastEvictAt(transaction: Transaction, now: Long) {
         transaction.store { store ->
             val stats = getOrCreate(store, key)
-            stats.last_evict_at = now
+            stats.last_evict_at = now.toDouble()
             store.put(stats)
         }
     }
@@ -29,7 +29,7 @@ internal class KottageIndexeddbStatsRepository : KottageStatsRepository {
         if (stats == null) {
             stats = jso {
                 this.key = key
-                last_evict_at = 0L
+                last_evict_at = 0L.toDouble()
             }
             store.add(stats)
         }

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbStatsRepository.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbStatsRepository.kt
@@ -1,11 +1,13 @@
 package io.github.irgaly.kottage.internal.repository
 
+import io.github.irgaly.kottage.internal.database.Transaction
+
 internal class KottageIndexeddbStatsRepository : KottageStatsRepository {
-    override fun getLastEvictAt(): Long {
+    override fun getLastEvictAt(transaction: Transaction): Long {
         TODO("Not yet implemented")
     }
 
-    override fun updateLastEvictAt(now: Long) {
+    override fun updateLastEvictAt(transaction: Transaction, now: Long) {
         TODO("Not yet implemented")
     }
 }

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbStatsRepository.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbStatsRepository.kt
@@ -3,11 +3,11 @@ package io.github.irgaly.kottage.internal.repository
 import io.github.irgaly.kottage.internal.database.Transaction
 
 internal class KottageIndexeddbStatsRepository : KottageStatsRepository {
-    override fun getLastEvictAt(transaction: Transaction): Long {
+    override suspend fun getLastEvictAt(transaction: Transaction): Long {
         TODO("Not yet implemented")
     }
 
-    override fun updateLastEvictAt(transaction: Transaction, now: Long) {
+    override suspend fun updateLastEvictAt(transaction: Transaction, now: Long) {
         TODO("Not yet implemented")
     }
 }

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbStatsRepository.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbStatsRepository.kt
@@ -1,13 +1,45 @@
 package io.github.irgaly.kottage.internal.repository
 
+import com.juul.indexeddb.Key
+import com.juul.indexeddb.ObjectStore
+import com.juul.indexeddb.WriteTransaction
+import io.github.irgaly.kottage.data.indexeddb.KottageIndexeddbDatabase
+import io.github.irgaly.kottage.data.indexeddb.extension.jso
+import io.github.irgaly.kottage.data.indexeddb.schema.entity.Stats
 import io.github.irgaly.kottage.internal.database.Transaction
 
-internal class KottageIndexeddbStatsRepository : KottageStatsRepository {
+internal class KottageIndexeddbStatsRepository(
+    private val database: KottageIndexeddbDatabase
+) : KottageStatsRepository {
+    private val key = "kottage"
+
     override suspend fun getLastEvictAt(transaction: Transaction): Long {
-        TODO("Not yet implemented")
+        return transaction.store { store ->
+            getOrCreate(store, key).last_evict_at
+        }
     }
 
     override suspend fun updateLastEvictAt(transaction: Transaction, now: Long) {
-        TODO("Not yet implemented")
+        transaction.store { store ->
+            val stats = getOrCreate(store, key)
+            stats.last_evict_at = now
+            store.put(stats)
+        }
+    }
+
+    private suspend fun WriteTransaction.getOrCreate(store: ObjectStore, key: String): Stats {
+        var stats = store.get(Key(key))?.unsafeCast<Stats>()
+        if (stats == null) {
+            stats = jso {
+                this.key = key
+                last_evict_at = 0L
+            }
+            store.add(stats)
+        }
+        return stats
+    }
+
+    private inline fun <R> Transaction.store(block: WriteTransaction.(store: ObjectStore) -> R): R {
+        return with(transaction) { block(transaction.objectStore("stats")) }
     }
 }

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageRepositoryFactory.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageRepositoryFactory.kt
@@ -16,6 +16,7 @@ import io.github.irgaly.kottage.internal.database.DatabaseConnection
  *         * cursor Flow の collect 内で他の indexxeddb 非同期処理を実行すると
  *           collect 処理が最後まで進む前に cursor.continue() が実行され、次の collect 処理が並列で走ってしまう
  *         * Transaction 内の並列処理は整合性が保てないため、cursor Flow 内では非同期処理を使わないようにする
+ *         * 例外として: cursor.delete() だけの実行なら許可する
  */
 internal actual class KottageRepositoryFactory actual constructor(
     private val databaseConnection: DatabaseConnection

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageRepositoryFactory.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageRepositoryFactory.kt
@@ -2,12 +2,13 @@ package io.github.irgaly.kottage.internal.repository
 
 import io.github.irgaly.kottage.internal.database.DatabaseConnection
 
-internal actual class KottageRepositoryFactory actual constructor(
-    databaseConnection: DatabaseConnection
-) {
-
+internal actual class KottageRepositoryFactory actual constructor(databaseConnection: DatabaseConnection) {
     actual suspend fun createItemRepository(): KottageItemRepository {
         return KottageIndexeddbItemRepository()
+    }
+
+    actual suspend fun createItemListRepository(): KottageItemListRepository {
+        return KottageIndexeddbItemListRepository()
     }
 
     actual suspend fun createItemEventRepository(): KottageItemEventRepository {

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageRepositoryFactory.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageRepositoryFactory.kt
@@ -2,22 +2,29 @@ package io.github.irgaly.kottage.internal.repository
 
 import io.github.irgaly.kottage.internal.database.DatabaseConnection
 
+/**
+ * Note:
+ * * indexeddb comparison
+ *     * https://stackoverflow.com/a/15625231/13403244
+ *     * https://w3c.github.io/IndexedDB/#key-construct
+ *     * null は index に含まれない
+ */
 internal actual class KottageRepositoryFactory actual constructor(
     private val databaseConnection: DatabaseConnection
 ) {
     actual suspend fun createItemRepository(): KottageItemRepository {
-        return KottageIndexeddbItemRepository(databaseConnection.database.await())
+        return KottageIndexeddbItemRepository()
     }
 
     actual suspend fun createItemListRepository(): KottageItemListRepository {
-        return KottageIndexeddbItemListRepository(databaseConnection.database.await())
+        return KottageIndexeddbItemListRepository()
     }
 
     actual suspend fun createItemEventRepository(): KottageItemEventRepository {
-        return KottageIndexeddbItemEventRepository(databaseConnection.database.await())
+        return KottageIndexeddbItemEventRepository()
     }
 
     actual suspend fun createStatsRepository(): KottageStatsRepository {
-        return KottageIndexeddbStatsRepository(databaseConnection.database.await())
+        return KottageIndexeddbStatsRepository()
     }
 }

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageRepositoryFactory.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageRepositoryFactory.kt
@@ -2,20 +2,22 @@ package io.github.irgaly.kottage.internal.repository
 
 import io.github.irgaly.kottage.internal.database.DatabaseConnection
 
-internal actual class KottageRepositoryFactory actual constructor(databaseConnection: DatabaseConnection) {
+internal actual class KottageRepositoryFactory actual constructor(
+    private val databaseConnection: DatabaseConnection
+) {
     actual suspend fun createItemRepository(): KottageItemRepository {
-        return KottageIndexeddbItemRepository()
+        return KottageIndexeddbItemRepository(databaseConnection.database.await())
     }
 
     actual suspend fun createItemListRepository(): KottageItemListRepository {
-        return KottageIndexeddbItemListRepository()
+        return KottageIndexeddbItemListRepository(databaseConnection.database.await())
     }
 
     actual suspend fun createItemEventRepository(): KottageItemEventRepository {
-        return KottageIndexeddbItemEventRepository()
+        return KottageIndexeddbItemEventRepository(databaseConnection.database.await())
     }
 
     actual suspend fun createStatsRepository(): KottageStatsRepository {
-        return KottageIndexeddbStatsRepository()
+        return KottageIndexeddbStatsRepository(databaseConnection.database.await())
     }
 }

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageRepositoryFactory.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageRepositoryFactory.kt
@@ -8,6 +8,8 @@ import io.github.irgaly.kottage.internal.database.DatabaseConnection
  *     * https://stackoverflow.com/a/15625231/13403244
  *     * https://w3c.github.io/IndexedDB/#key-construct
  *     * null は index に含まれない
+ * * Kotlin/JS
+ *     * external types https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.js/-js-export/
  */
 internal actual class KottageRepositoryFactory actual constructor(
     private val databaseConnection: DatabaseConnection

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageRepositoryFactory.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageRepositoryFactory.kt
@@ -10,6 +10,12 @@ import io.github.irgaly.kottage.internal.database.DatabaseConnection
  *     * null は index に含まれない
  * * Kotlin/JS
  *     * external types https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.js/-js-export/
+ * * Kotlin indexeddb
+ *     * https://github.com/JuulLabs/indexeddb
+ *     * v0.3.0 Issue
+ *         * cursor Flow の collect 内で他の indexxeddb 非同期処理を実行すると
+ *           collect 処理が最後まで進む前に cursor.continue() が実行され、次の collect 処理が並列で走ってしまう
+ *         * Transaction 内の並列処理は整合性が保てないため、cursor Flow 内では非同期処理を使わないようにする
  */
 internal actual class KottageRepositoryFactory actual constructor(
     private val databaseConnection: DatabaseConnection

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/Translators.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/Translators.kt
@@ -25,7 +25,7 @@ internal fun io.github.irgaly.kottage.data.indexeddb.schema.entity.Item.toDomain
 internal fun Item.toEntity(): io.github.irgaly.kottage.data.indexeddb.schema.entity.Item {
     return jso {
         key = getEntityKey()
-        type = type
+        type = this@toEntity.type
         string_value = stringValue
         long_value = longValue
         double_value = doubleValue
@@ -54,8 +54,8 @@ internal fun io.github.irgaly.kottage.data.indexeddb.schema.entity.Item_list.toD
 
 internal fun ItemListEntry.toEntity(): io.github.irgaly.kottage.data.indexeddb.schema.entity.Item_list {
     return jso {
-        id = id
-        type = type
+        id = this@toEntity.id
+        type = this@toEntity.type
         item_type = itemType
         item_key = itemKey
         previous_id = previousId
@@ -100,7 +100,7 @@ internal fun io.github.irgaly.kottage.data.indexeddb.schema.entity.Item_event.to
 
 internal fun ItemEvent.toEntity(): io.github.irgaly.kottage.data.indexeddb.schema.entity.Item_event {
     return jso {
-        id = id
+        id = this@toEntity.id
         created_at = createdAt
         expire_at = expireAt
         item_type = itemType

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/Translators.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/Translators.kt
@@ -13,12 +13,12 @@ internal fun io.github.irgaly.kottage.data.indexeddb.schema.entity.Item.toDomain
         key = Item.keyFromEntityKey(key, type),
         type = type,
         stringValue = string_value,
-        longValue = long_value,
+        longValue = long_value?.toLong(),
         doubleValue = double_value,
         bytesValue = bytes_value,
-        createdAt = created_at,
-        lastReadAt = last_read_at,
-        expireAt = expire_at
+        createdAt = created_at.toLong(),
+        lastReadAt = last_read_at.toLong(),
+        expireAt = expire_at?.toLong()
     )
 }
 
@@ -27,12 +27,12 @@ internal fun Item.toEntity(): io.github.irgaly.kottage.data.indexeddb.schema.ent
         key = getEntityKey()
         type = this@toEntity.type
         string_value = stringValue
-        long_value = longValue
+        long_value = longValue?.toString()
         double_value = doubleValue
         bytes_value = bytesValue
-        created_at = createdAt
-        last_read_at = lastReadAt
-        expire_at = expireAt
+        created_at = createdAt.toDouble()
+        last_read_at = lastReadAt.toDouble()
+        expire_at = expireAt?.toDouble()
     }
 }
 
@@ -44,7 +44,7 @@ internal fun io.github.irgaly.kottage.data.indexeddb.schema.entity.Item_list.toD
         itemKey = item_key,
         previousId = previous_id,
         nextId = next_id,
-        expireAt = expire_at,
+        expireAt = expire_at?.toLong(),
         userInfo = user_info,
         userPreviousKey = user_previous_key,
         userCurrentKey = user_current_key,
@@ -60,7 +60,7 @@ internal fun ItemListEntry.toEntity(): io.github.irgaly.kottage.data.indexeddb.s
         item_key = itemKey
         previous_id = previousId
         next_id = nextId
-        expire_at = expireAt
+        expire_at = expireAt?.toDouble()
         user_info = userInfo
         user_previous_key = userPreviousKey
         user_current_key = userCurrentKey
@@ -71,15 +71,15 @@ internal fun ItemListEntry.toEntity(): io.github.irgaly.kottage.data.indexeddb.s
 internal fun io.github.irgaly.kottage.data.indexeddb.schema.entity.Item_stats.toDomain(): ItemStats {
     return ItemStats(
         itemType = item_type,
-        count = count,
-        eventCount = event_count
+        count = count.toLong(),
+        eventCount = event_count.toLong()
     )
 }
 
 internal fun io.github.irgaly.kottage.data.indexeddb.schema.entity.Item_list_stats.toDomain(): ItemListStats {
     return ItemListStats(
         listType = item_list_type,
-        count = count,
+        count = count.toLong(),
         firstItemPositionId = first_item_list_id,
         lastItemPositionId = last_item_list_id
     )
@@ -88,21 +88,23 @@ internal fun io.github.irgaly.kottage.data.indexeddb.schema.entity.Item_list_sta
 internal fun io.github.irgaly.kottage.data.indexeddb.schema.entity.Item_event.toDomain(): ItemEvent {
     return ItemEvent(
         id = id,
-        createdAt = created_at,
-        expireAt = expire_at,
+        createdAt = created_at.toLong(),
+        expireAt = expire_at?.toLong(),
         itemType = item_type,
         itemKey = item_key,
         itemListId = item_list_id,
         itemListType = item_list_type,
-        eventType = io.github.irgaly.kottage.data.indexeddb.schema.entity.ItemEventType.valueOf(event_type).toDomain()
+        eventType = io.github.irgaly.kottage.data.indexeddb.schema.entity.ItemEventType.valueOf(
+            event_type
+        ).toDomain()
     )
 }
 
 internal fun ItemEvent.toEntity(): io.github.irgaly.kottage.data.indexeddb.schema.entity.Item_event {
     return jso {
         id = this@toEntity.id
-        created_at = createdAt
-        expire_at = expireAt
+        created_at = createdAt.toDouble()
+        expire_at = expireAt?.toDouble()
         item_type = itemType
         item_key = itemKey
         item_list_id = itemListId

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/Translators.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/Translators.kt
@@ -1,0 +1,128 @@
+package io.github.irgaly.kottage.internal.repository
+
+import io.github.irgaly.kottage.data.indexeddb.extension.jso
+import io.github.irgaly.kottage.internal.model.Item
+import io.github.irgaly.kottage.internal.model.ItemEvent
+import io.github.irgaly.kottage.internal.model.ItemEventType
+import io.github.irgaly.kottage.internal.model.ItemListEntry
+import io.github.irgaly.kottage.internal.model.ItemListStats
+import io.github.irgaly.kottage.internal.model.ItemStats
+
+internal fun io.github.irgaly.kottage.data.indexeddb.schema.entity.Item.toDomain(): Item {
+    return Item(
+        key = Item.keyFromEntityKey(key, type),
+        type = type,
+        stringValue = string_value,
+        longValue = long_value,
+        doubleValue = double_value,
+        bytesValue = bytes_value,
+        createdAt = created_at,
+        lastReadAt = last_read_at,
+        expireAt = expire_at
+    )
+}
+
+internal fun Item.toEntity(): io.github.irgaly.kottage.data.indexeddb.schema.entity.Item {
+    return jso {
+        key = getEntityKey()
+        type = type
+        string_value = stringValue
+        long_value = longValue
+        double_value = doubleValue
+        bytes_value = bytesValue
+        created_at = createdAt
+        last_read_at = lastReadAt
+        expire_at = expireAt
+    }
+}
+
+internal fun io.github.irgaly.kottage.data.indexeddb.schema.entity.Item_list.toDomain(): ItemListEntry {
+    return ItemListEntry(
+        id = id,
+        type = type,
+        itemType = item_type,
+        itemKey = item_key,
+        previousId = previous_id,
+        nextId = next_id,
+        expireAt = expire_at,
+        userInfo = user_info,
+        userPreviousKey = user_previous_key,
+        userCurrentKey = user_current_key,
+        userNextKey = user_next_key
+    )
+}
+
+internal fun ItemListEntry.toEntity(): io.github.irgaly.kottage.data.indexeddb.schema.entity.Item_list {
+    return jso {
+        id = id
+        type = type
+        item_type = itemType
+        item_key = itemKey
+        previous_id = previousId
+        next_id = nextId
+        expire_at = expireAt
+        user_info = userInfo
+        user_previous_key = userPreviousKey
+        user_current_key = userCurrentKey
+        user_next_key = userNextKey
+    }
+}
+
+internal fun io.github.irgaly.kottage.data.indexeddb.schema.entity.Item_stats.toDomain(): ItemStats {
+    return ItemStats(
+        itemType = item_type,
+        count = count,
+        eventCount = event_count
+    )
+}
+
+internal fun io.github.irgaly.kottage.data.indexeddb.schema.entity.Item_list_stats.toDomain(): ItemListStats {
+    return ItemListStats(
+        listType = item_list_type,
+        count = count,
+        firstItemPositionId = first_item_list_id,
+        lastItemPositionId = last_item_list_id
+    )
+}
+
+internal fun io.github.irgaly.kottage.data.indexeddb.schema.entity.Item_event.toDomain(): ItemEvent {
+    return ItemEvent(
+        id = id,
+        createdAt = created_at,
+        expireAt = expire_at,
+        itemType = item_type,
+        itemKey = item_key,
+        itemListId = item_list_id,
+        itemListType = item_list_type,
+        eventType = io.github.irgaly.kottage.data.indexeddb.schema.entity.ItemEventType.valueOf(event_type).toDomain()
+    )
+}
+
+internal fun ItemEvent.toEntity(): io.github.irgaly.kottage.data.indexeddb.schema.entity.Item_event {
+    return jso {
+        id = id
+        created_at = createdAt
+        expire_at = expireAt
+        item_type = itemType
+        item_key = itemKey
+        item_list_id = itemListId
+        item_list_type = itemListType
+        event_type = eventType.toEntity().name
+    }
+}
+
+internal fun ItemEventType.toEntity(): io.github.irgaly.kottage.data.indexeddb.schema.entity.ItemEventType {
+    return when (this) {
+        ItemEventType.Create -> io.github.irgaly.kottage.data.indexeddb.schema.entity.ItemEventType.Create
+        ItemEventType.Update -> io.github.irgaly.kottage.data.indexeddb.schema.entity.ItemEventType.Update
+        ItemEventType.Delete -> io.github.irgaly.kottage.data.indexeddb.schema.entity.ItemEventType.Delete
+    }
+}
+
+internal fun io.github.irgaly.kottage.data.indexeddb.schema.entity.ItemEventType.toDomain(): ItemEventType {
+    return when (this) {
+        io.github.irgaly.kottage.data.indexeddb.schema.entity.ItemEventType.Create -> ItemEventType.Create
+        io.github.irgaly.kottage.data.indexeddb.schema.entity.ItemEventType.Update -> ItemEventType.Update
+        io.github.irgaly.kottage.data.indexeddb.schema.entity.ItemEventType.Delete -> ItemEventType.Delete
+    }
+}

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/KottageEventFlow.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/KottageEventFlow.kt
@@ -54,7 +54,7 @@ class KottageEventFlow internal constructor(
                     while (remains) {
                         val events = databaseConnection.transactionWithResult {
                             operator.getEvents(
-                                this,
+                                this@transactionWithResult,
                                 afterUnixTimeMillisAt = lastEventTime,
                                 itemType = itemType,
                                 limit = limit

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/KottageEventFlow.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/KottageEventFlow.kt
@@ -54,6 +54,7 @@ class KottageEventFlow internal constructor(
                     while (remains) {
                         val events = databaseConnection.transactionWithResult {
                             operator.getEvents(
+                                this,
                                 afterUnixTimeMillisAt = lastEventTime,
                                 itemType = itemType,
                                 limit = limit

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageDatabaseManager.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageDatabaseManager.kt
@@ -102,10 +102,10 @@ internal class KottageDatabaseManager(
         )
     }
 
-    suspend fun <R> transactionWithResult(bodyWithReturn: Transaction.() -> R): R =
+    suspend fun <R> transactionWithResult(bodyWithReturn: suspend Transaction.() -> R): R =
         databaseConnection.transactionWithResult(bodyWithReturn)
 
-    suspend fun transaction(body: Transaction.() -> Unit) = databaseConnection.transaction(body)
+    suspend fun transaction(body: suspend Transaction.() -> Unit) = databaseConnection.transaction(body)
     suspend fun deleteAll() {
         databaseConnection.deleteAll()
     }

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageDatabaseManager.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageDatabaseManager.kt
@@ -5,6 +5,7 @@ import io.github.irgaly.kottage.KottageEventFlow
 import io.github.irgaly.kottage.KottageList
 import io.github.irgaly.kottage.KottageOptions
 import io.github.irgaly.kottage.KottageStorage
+import io.github.irgaly.kottage.internal.database.Transaction
 import io.github.irgaly.kottage.internal.database.createDatabaseConnection
 import io.github.irgaly.kottage.internal.model.ItemEvent
 import io.github.irgaly.kottage.internal.model.ItemEventFlow
@@ -101,10 +102,10 @@ internal class KottageDatabaseManager(
         )
     }
 
-    suspend fun <R> transactionWithResult(bodyWithReturn: () -> R): R =
+    suspend fun <R> transactionWithResult(bodyWithReturn: Transaction.() -> R): R =
         databaseConnection.transactionWithResult(bodyWithReturn)
 
-    suspend fun transaction(body: () -> Unit) = databaseConnection.transaction(body)
+    suspend fun transaction(body: Transaction.() -> Unit) = databaseConnection.transaction(body)
     suspend fun deleteAll() {
         databaseConnection.deleteAll()
     }

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageDatabaseManager.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageDatabaseManager.kt
@@ -117,22 +117,23 @@ internal class KottageDatabaseManager(
             now - it.inWholeMilliseconds
         }
         val compactionRequired = databaseConnection.transactionWithResult {
-            val required = (force || operator.getAutoCompactionNeeded(now))
+            val required = (force || operator.getAutoCompactionNeeded(this, now))
             if (required) {
                 if (beforeExpireAt != null) {
                     // List Entry の自動削除が有効
                     operator.evictExpiredListEntries(
+                        this,
                         now = now,
                         beforeExpireAt = beforeExpireAt
                     )
                 } else {
                     // List Entry Invalidate のみ
-                    operator.invalidateExpiredListEntries(now = now)
+                    operator.invalidateExpiredListEntries(this, now = now)
                 }
-                operator.evictCaches(now)
-                operator.evictEvents(now)
-                operator.evictEmptyStats()
-                operator.updateLastEvictAt(now)
+                operator.evictCaches(this, now)
+                operator.evictEvents(this, now)
+                operator.evictEmptyStats(this)
+                operator.updateLastEvictAt(this, now)
             }
             required
         }
@@ -161,6 +162,7 @@ internal class KottageDatabaseManager(
             while (remains) {
                 val events = databaseConnection.transactionWithResult {
                     operator.getEvents(
+                        this,
                         afterUnixTimeMillisAt = lastEventTime,
                         limit = limit
                     )

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageListImpl.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageListImpl.kt
@@ -939,7 +939,7 @@ internal class KottageListImpl(
 
     private suspend fun <R> transactionWithAutoCompaction(
         now: Long? = null,
-        bodyWithReturn: Transaction.(operator: KottageOperator, now: Long) -> R
+        bodyWithReturn: suspend Transaction.(operator: KottageOperator, now: Long) -> R
     ): R {
         val operator = operator()
         val receivedNow = now ?: calendar.nowUnixTimeMillis()

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageListImpl.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageListImpl.kt
@@ -9,6 +9,7 @@ import io.github.irgaly.kottage.KottageListPage
 import io.github.irgaly.kottage.KottageListValue
 import io.github.irgaly.kottage.KottageOptions
 import io.github.irgaly.kottage.KottageStorage
+import io.github.irgaly.kottage.internal.database.Transaction
 import io.github.irgaly.kottage.internal.encoder.Encoder
 import io.github.irgaly.kottage.internal.encoder.encodeItem
 import io.github.irgaly.kottage.internal.model.ItemListEntry
@@ -927,7 +928,7 @@ internal class KottageListImpl(
 
     private suspend fun <R> transactionWithAutoCompaction(
         now: Long? = null,
-        bodyWithReturn: (operator: KottageOperator, now: Long) -> R
+        bodyWithReturn: Transaction.(operator: KottageOperator, now: Long) -> R
     ): R {
         val operator = operator()
         val receivedNow = now ?: calendar.nowUnixTimeMillis()

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageListOperator.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageListOperator.kt
@@ -34,7 +34,7 @@ internal class KottageListOperator(
      *
      * @param entries previousId, nextId が正しく設定された Entry
      */
-    fun addListEntries(
+    suspend fun addListEntries(
         transaction: Transaction,
         entries: List<ItemListEntry>,
         now: Long
@@ -108,7 +108,7 @@ internal class KottageListOperator(
      *
      * positionId の ItemListEntry を取得する
      */
-    fun getListItem(
+    suspend fun getListItem(
         transaction: Transaction,
         positionId: String
     ): ItemListEntry? {
@@ -122,7 +122,7 @@ internal class KottageListOperator(
      *
      * positionId からたどり、有効な Entry があればそれを返す
      */
-    fun getAvailableListEntry(
+    suspend fun getAvailableListEntry(
         transaction: Transaction,
         positionId: String,
         direction: KottageListDirection
@@ -150,7 +150,7 @@ internal class KottageListOperator(
     /**
      * This should be called in transaction
      */
-    fun removeListItem(
+    suspend fun removeListItem(
         transaction: Transaction,
         positionId: String,
         now: Long
@@ -186,21 +186,21 @@ internal class KottageListOperator(
     /**
      * This should be called in transaction
      */
-    fun getFirstItemPositionId(transaction: Transaction): String? {
+    suspend fun getFirstItemPositionId(transaction: Transaction): String? {
         return itemListRepository.getStats(transaction, listType)?.firstItemPositionId
     }
 
     /**
      * This should be called in transaction
      */
-    fun getLastItemPositionId(transaction: Transaction): String? {
+    suspend fun getLastItemPositionId(transaction: Transaction): String? {
         return itemListRepository.getStats(transaction, listType)?.lastItemPositionId
     }
 
     /**
      * This should be called in transaction
      */
-    fun updateItemKey(
+    suspend fun updateItemKey(
         transaction: Transaction,
         positionId: String,
         item: Item,
@@ -233,7 +233,7 @@ internal class KottageListOperator(
      *
      * * リスト全体から削除可能な entity を取り除く
      */
-    fun evictExpiredEntries(
+    suspend fun evictExpiredEntries(
         transaction: Transaction,
         now: Long
     ) {
@@ -248,7 +248,7 @@ internal class KottageListOperator(
     /**
      * This should be called in transaction
      */
-    fun invalidateExpiredListEntries(
+    suspend fun invalidateExpiredListEntries(
         transaction: Transaction,
         now: Long
     ) {
@@ -258,7 +258,7 @@ internal class KottageListOperator(
     /**
      * This should be called in transaction
      */
-    fun clear(transaction: Transaction) {
+    suspend fun clear(transaction: Transaction) {
         itemListRepository.deleteAll(transaction, type = listType)
         itemListRepository.deleteStats(transaction, type = listType)
         itemEventRepository.deleteAllList(transaction, listType = listType)
@@ -267,7 +267,7 @@ internal class KottageListOperator(
     /**
      * This should be called in transaction
      */
-    fun getDebugStatus(transaction: Transaction): String {
+    suspend fun getDebugStatus(transaction: Transaction): String {
         val stats = itemListRepository.getStats(transaction, type = listType)
         val invalidatedItemsCount =
             itemListRepository.getInvalidatedItemCount(transaction, type = listType)
@@ -282,7 +282,7 @@ internal class KottageListOperator(
     /**
      * This should be called in transaction
      */
-    fun getDebugListRawData(transaction: Transaction): String {
+    suspend fun getDebugListRawData(transaction: Transaction): String {
         val data = StringBuilder()
         val stats = itemListRepository.getStats(transaction, type = listType)
         if (stats != null) {

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageListOperator.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageListOperator.kt
@@ -3,6 +3,7 @@ package io.github.irgaly.kottage.internal
 import io.github.irgaly.kottage.KottageListDirection
 import io.github.irgaly.kottage.KottageListOptions
 import io.github.irgaly.kottage.KottageStorageOptions
+import io.github.irgaly.kottage.internal.database.Transaction
 import io.github.irgaly.kottage.internal.model.Item
 import io.github.irgaly.kottage.internal.model.ItemEventType
 import io.github.irgaly.kottage.internal.model.ItemListEntry
@@ -33,14 +34,19 @@ internal class KottageListOperator(
      *
      * @param entries previousId, nextId が正しく設定された Entry
      */
-    fun addListEntries(entries: List<ItemListEntry>, now: Long) {
+    fun addListEntries(
+        transaction: Transaction,
+        entries: List<ItemListEntry>,
+        now: Long
+    ) {
         if (entries.isNotEmpty()) {
-            val hasStats = (itemListRepository.getStats(type = listType) != null)
+            val hasStats = (itemListRepository.getStats(transaction, type = listType) != null)
             val first = entries.first()
             val last = entries.last()
             entries.forEach { entry ->
-                itemListRepository.upsert(entry)
+                itemListRepository.upsert(transaction, entry)
                 operator.addEvent(
+                    transaction,
                     now = now,
                     eventType = ItemEventType.Create,
                     eventExpireTime = storageOptions.eventExpireTime,
@@ -52,30 +58,42 @@ internal class KottageListOperator(
                 )
             }
             first.previousId?.let { previousId ->
-                itemListRepository.updateNextId(id = previousId, nextId = first.id)
+                itemListRepository.updateNextId(
+                    transaction,
+                    id = previousId,
+                    nextId = first.id
+                )
             }
             last.nextId?.let { nextId ->
-                itemListRepository.updatePreviousId(id = nextId, previousId = last.id)
+                itemListRepository.updatePreviousId(
+                    transaction,
+                    id = nextId,
+                    previousId = last.id
+                )
             }
             if (hasStats) {
                 if (first.isFirst) {
                     itemListRepository.updateStatsFirstItem(
+                        transaction,
                         type = listType,
                         id = first.id
                     )
                 }
                 if (last.isLast) {
                     itemListRepository.updateStatsLastItem(
+                        transaction,
                         type = listType,
                         id = last.id
                     )
                 }
                 itemListRepository.incrementStatsCount(
+                    transaction,
                     type = listType,
                     count = entries.size.toLong()
                 )
             } else {
                 itemListRepository.createStats(
+                    transaction,
                     type = listType,
                     count = entries.size.toLong(),
                     firstItemListEntryId = entries.first().id,
@@ -91,9 +109,10 @@ internal class KottageListOperator(
      * positionId の ItemListEntry を取得する
      */
     fun getListItem(
+        transaction: Transaction,
         positionId: String
     ): ItemListEntry? {
-        return itemListRepository.get(positionId)?.let { entry ->
+        return itemListRepository.get(transaction, positionId)?.let { entry ->
             if (entry.type == listType) entry else null
         }
     }
@@ -104,13 +123,14 @@ internal class KottageListOperator(
      * positionId からたどり、有効な Entry があればそれを返す
      */
     fun getAvailableListEntry(
+        transaction: Transaction,
         positionId: String,
         direction: KottageListDirection
     ): ItemListEntry? {
         var nextId: String? = positionId
         var entry: ItemListEntry? = null
         while (entry == null && nextId != null) {
-            val current = itemListRepository.get(nextId)
+            val current = itemListRepository.get(transaction, nextId)
             nextId = when (direction) {
                 KottageListDirection.Forward -> current?.nextId
                 KottageListDirection.Backward -> current?.previousId
@@ -130,20 +150,26 @@ internal class KottageListOperator(
     /**
      * This should be called in transaction
      */
-    fun removeListItem(positionId: String, now: Long): Boolean {
-        val entry = itemListRepository.get(positionId)
+    fun removeListItem(
+        transaction: Transaction,
+        positionId: String,
+        now: Long
+    ): Boolean {
+        val entry = itemListRepository.get(transaction, positionId)
         return if ((entry != null) &&
             entry.itemExists &&
             (entry.type == listType)
         ) {
             val itemKey = checkNotNull(entry.itemKey)
             storageOperator.removeListItemInternal(
+                transaction,
                 positionId = positionId,
                 listType = listType,
                 now = now,
                 entry = entry
             )
             operator.addEvent(
+                transaction,
                 now = now,
                 eventType = ItemEventType.Delete,
                 eventExpireTime = storageOptions.eventExpireTime,
@@ -160,26 +186,28 @@ internal class KottageListOperator(
     /**
      * This should be called in transaction
      */
-    fun getFirstItemPositionId(): String? {
-        return itemListRepository.getStats(listType)?.firstItemPositionId
+    fun getFirstItemPositionId(transaction: Transaction): String? {
+        return itemListRepository.getStats(transaction, listType)?.firstItemPositionId
     }
 
     /**
      * This should be called in transaction
      */
-    fun getLastItemPositionId(): String? {
-        return itemListRepository.getStats(listType)?.lastItemPositionId
+    fun getLastItemPositionId(transaction: Transaction): String? {
+        return itemListRepository.getStats(transaction, listType)?.lastItemPositionId
     }
 
     /**
      * This should be called in transaction
      */
     fun updateItemKey(
+        transaction: Transaction,
         positionId: String,
         item: Item,
         now: Long
     ) {
         itemListRepository.updateItemKey(
+            transaction,
             id = positionId,
             itemType = item.type,
             itemKey = item.key,
@@ -188,6 +216,7 @@ internal class KottageListOperator(
             }
         )
         operator.addEvent(
+            transaction,
             now = now,
             eventType = ItemEventType.Update,
             eventExpireTime = storageOptions.eventExpireTime,
@@ -204,37 +233,45 @@ internal class KottageListOperator(
      *
      * * リスト全体から削除可能な entity を取り除く
      */
-    fun evictExpiredEntries(now: Long) {
+    fun evictExpiredEntries(
+        transaction: Transaction,
+        now: Long
+    ) {
         operator.evictExpiredListEntries(
-            listType = listType,
+            transaction,
             now = now,
-            beforeExpireAt = null
+            beforeExpireAt = null,
+            listType = listType
         )
     }
 
     /**
      * This should be called in transaction
      */
-    fun invalidateExpiredListEntries(now: Long) {
-        operator.invalidateExpiredListEntries(now = now, listType = listType)
+    fun invalidateExpiredListEntries(
+        transaction: Transaction,
+        now: Long
+    ) {
+        operator.invalidateExpiredListEntries(transaction, now = now, listType = listType)
     }
 
     /**
      * This should be called in transaction
      */
-    fun clear() {
-        itemListRepository.deleteAll(type = listType)
-        itemListRepository.deleteStats(type = listType)
-        itemEventRepository.deleteAllList(listType = listType)
+    fun clear(transaction: Transaction) {
+        itemListRepository.deleteAll(transaction, type = listType)
+        itemListRepository.deleteStats(transaction, type = listType)
+        itemEventRepository.deleteAllList(transaction, listType = listType)
     }
 
     /**
      * This should be called in transaction
      */
-    fun getDebugStatus(): String {
-        val stats = itemListRepository.getStats(type = listType)
-        val invalidatedItemsCount = itemListRepository.getInvalidatedItemCount(type = listType)
-        val itemsCount = itemListRepository.getCount(type = listType)
+    fun getDebugStatus(transaction: Transaction): String {
+        val stats = itemListRepository.getStats(transaction, type = listType)
+        val invalidatedItemsCount =
+            itemListRepository.getInvalidatedItemCount(transaction, type = listType)
+        val itemsCount = itemListRepository.getCount(transaction, type = listType)
         return """
         available items: ${stats?.count ?: "(no stats)"}
         invalidated items: $invalidatedItemsCount
@@ -245,17 +282,21 @@ internal class KottageListOperator(
     /**
      * This should be called in transaction
      */
-    fun getDebugListRawData(): String {
+    fun getDebugListRawData(transaction: Transaction): String {
         val data = StringBuilder()
-        val stats = itemListRepository.getStats(type = listType)
+        val stats = itemListRepository.getStats(transaction, type = listType)
         if (stats != null) {
             var nextId: String? = stats.firstItemPositionId
             data.appendLine("[first] ${stats.firstItemPositionId}")
             while (nextId != null) {
-                val entry = itemListRepository.get(nextId)
+                val entry = itemListRepository.get(transaction, nextId)
                 if (entry != null) {
                     val item = entry.itemKey?.let { itemKey ->
-                        itemRepository.get(key = itemKey, itemType = entry.itemType)
+                        itemRepository.get(
+                            transaction,
+                            key = itemKey,
+                            itemType = entry.itemType
+                        )
                     }
                     data.appendLine(
                         "-> [${entry.id} : expireAt = ${entry.expireAt}]"

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageOperator.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageOperator.kt
@@ -1,6 +1,7 @@
 package io.github.irgaly.kottage.internal
 
 import io.github.irgaly.kottage.KottageOptions
+import io.github.irgaly.kottage.internal.database.Transaction
 import io.github.irgaly.kottage.internal.model.ItemEvent
 import io.github.irgaly.kottage.internal.model.ItemEventType
 import io.github.irgaly.kottage.internal.model.ItemListEntry
@@ -11,6 +12,7 @@ import io.github.irgaly.kottage.internal.repository.KottageItemRepository
 import io.github.irgaly.kottage.internal.repository.KottageStatsRepository
 import io.github.irgaly.kottage.platform.Id
 import io.github.irgaly.kottage.strategy.KottageStrategyOperator
+import io.github.irgaly.kottage.strategy.KottageTransaction
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -30,6 +32,7 @@ internal class KottageOperator(
      * @return Event id
      */
     fun addEvent(
+        transaction: Transaction,
         now: Long,
         eventType: ItemEventType,
         eventExpireTime: Duration?,
@@ -40,6 +43,7 @@ internal class KottageOperator(
         maxEventEntryCount: Long
     ): String {
         val id = addEventInternal(
+            transaction,
             now = now,
             eventExpireTime = eventExpireTime,
             itemType = itemType,
@@ -48,8 +52,8 @@ internal class KottageOperator(
             itemListType = itemListType,
             eventType = eventType
         )
-        itemEventRepository.incrementStatsCount(itemType, 1)
-        reduceEvents(now, itemType, maxEventEntryCount)
+        itemEventRepository.incrementStatsCount(transaction, itemType, 1)
+        reduceEvents(transaction, now, itemType, maxEventEntryCount)
         return id
     }
 
@@ -58,11 +62,13 @@ internal class KottageOperator(
      * This should be called in transaction
      */
     fun getEvents(
+        transaction: Transaction,
         afterUnixTimeMillisAt: Long,
         itemType: String? = null,
         limit: Long? = null
     ): List<ItemEvent> {
         return itemEventRepository.selectAfter(
+            transaction,
             createdAt = afterUnixTimeMillisAt,
             itemType = itemType,
             limit = limit
@@ -72,9 +78,9 @@ internal class KottageOperator(
     /**
      * This should be called in transaction
      */
-    fun getAutoCompactionNeeded(now: Long): Boolean {
+    fun getAutoCompactionNeeded(transaction: Transaction, now: Long): Boolean {
         return options.autoCompactionDuration?.let { duration ->
-            val lastCompaction = statsRepository.getLastEvictAt()
+            val lastCompaction = statsRepository.getLastEvictAt(transaction)
             (duration <= (now - lastCompaction).milliseconds)
         } ?: false
     }
@@ -82,8 +88,8 @@ internal class KottageOperator(
     /**
      * This should be called in transaction
      */
-    fun getAllListType(receiver: (listType: String) -> Unit) {
-        itemListRepository.getAllTypes(receiver)
+    fun getAllListType(transaction: Transaction, receiver: (listType: String) -> Unit) {
+        itemListRepository.getAllTypes(transaction, receiver)
     }
 
     /**
@@ -91,22 +97,22 @@ internal class KottageOperator(
      * existing items in ItemList are ignored
      * This should be called in transaction
      */
-    fun evictCaches(now: Long, itemType: String? = null) {
+    fun evictCaches(transaction: Transaction, now: Long, itemType: String? = null) {
         if (itemType != null) {
-            itemRepository.getExpiredKeys(now, itemType) { key, _ ->
-                val itemListEntryIds = itemListRepository.getIds(itemType = itemType, itemKey = key)
+            itemRepository.getExpiredKeys(transaction, now, itemType) { key, _ ->
+                val itemListEntryIds = itemListRepository.getIds(transaction, itemType = itemType, itemKey = key)
                 if (itemListEntryIds.isEmpty()) {
                     // ItemList に存在しなければ削除可能
-                    deleteItemInternal(key, itemType)
+                    deleteItemInternal(transaction, key, itemType)
                 }
             }
         } else {
-            itemRepository.getExpiredKeys(now) { key, expiredItemType ->
+            itemRepository.getExpiredKeys(transaction, now) { key, expiredItemType ->
                 val itemListEntryIds =
-                    itemListRepository.getIds(itemType = expiredItemType, itemKey = key)
+                    itemListRepository.getIds(transaction, itemType = expiredItemType, itemKey = key)
                 if (itemListEntryIds.isEmpty()) {
                     // ItemList に存在しなければ削除可能
-                    deleteItemInternal(key, expiredItemType)
+                    deleteItemInternal(transaction, key, expiredItemType)
                 }
             }
         }
@@ -116,14 +122,14 @@ internal class KottageOperator(
      * Delete old events
      * This should be called in transaction
      */
-    fun evictEvents(now: Long, itemType: String? = null) {
+    fun evictEvents(transaction: Transaction, now: Long, itemType: String? = null) {
         if (itemType != null) {
-            itemEventRepository.getExpiredIds(now, itemType) { id, _ ->
-                deleteEvent(id, itemType)
+            itemEventRepository.getExpiredIds(transaction, now, itemType) { id, _ ->
+                deleteEvent(transaction, id, itemType)
             }
         } else {
-            itemEventRepository.getExpiredIds(now) { id, type ->
-                deleteEvent(id, type)
+            itemEventRepository.getExpiredIds(transaction, now) { id, type ->
+                deleteEvent(transaction, id, type)
             }
         }
     }
@@ -131,13 +137,13 @@ internal class KottageOperator(
     /**
      * This should be called in transaction
      */
-    fun evictEmptyStats() {
+    fun evictEmptyStats(transaction: Transaction) {
         val limit = 100L
         var hasNext = true
         while (hasNext) {
-            val statsList = itemRepository.getEmptyStats(limit = limit)
+            val statsList = itemRepository.getEmptyStats(transaction, limit = limit)
             statsList.forEach { stats ->
-                itemRepository.deleteStats(stats.itemType)
+                itemRepository.deleteStats(transaction, stats.itemType)
             }
             hasNext = (limit <= statsList.size)
         }
@@ -146,18 +152,19 @@ internal class KottageOperator(
     /**
      * This should be called in transaction
      */
-    fun evictExpiredListEntries(now: Long, beforeExpireAt: Long?, listType: String? = null) {
+    fun evictExpiredListEntries(transaction: Transaction, now: Long, beforeExpireAt: Long?, listType: String? = null) {
         fun evict(listType: String) {
-            invalidateExpiredListEntries(now = now, listType = listType)
+            invalidateExpiredListEntries(transaction, now = now, listType = listType)
             var limit = 100L
             while (0 < limit) {
                 val invalidatedIds = itemListRepository.getInvalidatedItemIds(
+                    transaction,
                     type = listType,
                     beforeExpireAt = beforeExpireAt,
                     limit = limit
                 )
                 if (invalidatedIds.isNotEmpty()) {
-                    removeListEntries(listType = listType, positionIds = invalidatedIds)
+                    removeListEntries(transaction, listType = listType, positionIds = invalidatedIds)
                 }
                 if (invalidatedIds.size < limit) {
                     limit = 0
@@ -167,24 +174,24 @@ internal class KottageOperator(
         if (listType != null) {
             evict(listType = listType)
         } else {
-            getAllListType { evict(listType = it) }
+            getAllListType(transaction) { evict(listType = it) }
         }
     }
 
     /**
      * This should be called in transaction
      */
-    fun getListStats(listType: String): ItemListStats? {
-        return itemListRepository.getStats(type = listType)
+    fun getListStats(transaction: Transaction, listType: String): ItemListStats? {
+        return itemListRepository.getStats(transaction, type = listType)
     }
 
     /**
      * Get List Item Count
      * This should be called in transaction
      */
-    fun getListCount(listType: String, now: Long): Long {
-        invalidateExpiredListEntries(now = now, listType = listType)
-        return itemListRepository.getStatsCount(type = listType)
+    fun getListCount(transaction: Transaction, listType: String, now: Long): Long {
+        invalidateExpiredListEntries(transaction, now = now, listType = listType)
+        return itemListRepository.getStatsCount(transaction, type = listType)
     }
 
     /**
@@ -193,9 +200,9 @@ internal class KottageOperator(
      * 前後のアイテムと item_list_stats の先頭末尾情報を更新しながらアイテムを取り除く
      * 有効なアイテムを削除した場合は Delete Event を追加する
      */
-    fun removeListEntries(listType: String, positionIds: List<String>) {
+    fun removeListEntries(transaction: Transaction, listType: String, positionIds: List<String>) {
         val entries = positionIds.map {
-            itemListRepository.get(it)
+            itemListRepository.get(transaction, it)
         }.mapNotNull {
             if (it?.type == listType) {
                 it.id to it
@@ -237,32 +244,35 @@ internal class KottageOperator(
                 if (entry.itemExists) {
                     deleted++
                 }
-                itemListRepository.delete(entry.id)
+                itemListRepository.delete(transaction, entry.id)
             }
             if (newPreviousIds.isEmpty() && newNextIds.isEmpty()) {
                 // アップデート対象が存在しない = List が空になった
-                itemListRepository.deleteStats(type = listType)
+                itemListRepository.deleteStats(transaction, type = listType)
             } else {
                 newPreviousIds.forEach { (id, previousId) ->
-                    itemListRepository.updatePreviousId(id = id, previousId = previousId)
+                    itemListRepository.updatePreviousId(transaction, id = id, previousId = previousId)
                 }
                 newNextIds.forEach { (id, nextId) ->
-                    itemListRepository.updateNextId(id = id, nextId = nextId)
+                    itemListRepository.updateNextId(transaction, id = id, nextId = nextId)
                 }
                 if (newFirstId != null) {
                     itemListRepository.updateStatsFirstItem(
+                        transaction,
                         type = listType,
                         id = newFirstId
                     )
                 }
                 if (newLastId != null) {
                     itemListRepository.updateStatsLastItem(
+                        transaction,
                         type = listType,
                         id = newLastId
                     )
                 }
                 if (0 < deleted) {
                     itemListRepository.decrementStatsCount(
+                        transaction,
                         type = listType,
                         count = deleted
                     )
@@ -279,18 +289,18 @@ internal class KottageOperator(
      * * リストの末尾から、expired な entity を invalidate する
      *     * 非削除対象の entity が現れたら処理を止める
      */
-    fun invalidateExpiredListEntries(now: Long, listType: String? = null) {
+    fun invalidateExpiredListEntries(transaction: Transaction, now: Long, listType: String? = null) {
         fun invalidate(listType: String) {
-            itemListRepository.getStats(type = listType)?.let { stats ->
+            itemListRepository.getStats(transaction, type = listType)?.let { stats ->
                 var invalidated = 0L
                 val scanInvalidate = { startPositionId: String, block: (ItemListEntry) -> String? ->
                     var nextPositionId: String? = startPositionId
                     while ((nextPositionId != null) && (invalidated < stats.count)) {
-                        val entry = checkNotNull(itemListRepository.get(nextPositionId))
+                        val entry = checkNotNull(itemListRepository.get(transaction, nextPositionId))
                         val expired = entry.isExpired(now)
                         if (entry.itemExists && expired) {
-                            itemListRepository.removeItemKey(entry.id)
-                            itemListRepository.removeUserData(entry.id)
+                            itemListRepository.removeItemKey(transaction, entry.id)
+                            itemListRepository.removeUserData(transaction, entry.id)
                             invalidated++
                         }
                         nextPositionId = if (entry.itemExists && !expired) null else block(entry)
@@ -300,6 +310,7 @@ internal class KottageOperator(
                 scanInvalidate(stats.lastItemPositionId) { it.previousId }
                 if (0 < invalidated) {
                     itemListRepository.decrementStatsCount(
+                        transaction,
                         type = listType,
                         count = invalidated
                     )
@@ -309,56 +320,56 @@ internal class KottageOperator(
         if (listType != null) {
             invalidate(listType = listType)
         } else {
-            getAllListType { invalidate(listType = it) }
+            getAllListType(transaction) { invalidate(listType = it) }
         }
     }
 
     /**
      * This should be called in transaction
      */
-    fun updateLastEvictAt(now: Long) {
-        statsRepository.updateLastEvictAt(now)
+    fun updateLastEvictAt(transaction: Transaction, now: Long) {
+        statsRepository.updateLastEvictAt(transaction, now)
     }
 
-    override fun updateItemLastRead(key: String, itemType: String, now: Long) {
-        itemRepository.updateLastRead(key, itemType, now)
+    override fun updateItemLastRead(transaction: KottageTransaction, key: String, itemType: String, now: Long) {
+        itemRepository.updateLastRead(transaction.transaction, key, itemType, now)
     }
 
-    override fun deleteLeastRecentlyUsed(itemType: String, limit: Long) {
+    override fun deleteLeastRecentlyUsed(transaction: KottageTransaction, itemType: String, limit: Long) {
         var deleted = 0L
-        itemRepository.getLeastRecentlyUsedKeys(itemType, null) { key ->
-            val itemListEntryIds = itemListRepository.getIds(itemType = itemType, itemKey = key)
+        itemRepository.getLeastRecentlyUsedKeys(transaction.transaction, itemType, null) { key ->
+            val itemListEntryIds = itemListRepository.getIds(transaction.transaction, itemType = itemType, itemKey = key)
             if (itemListEntryIds.isEmpty()) {
                 // ItemList に存在しなければ削除可能
-                deleteItemInternal(key, itemType)
+                deleteItemInternal(transaction.transaction, key, itemType)
                 deleted++
             }
             (deleted < limit)
         }
     }
 
-    override fun deleteOlderItems(itemType: String, limit: Long) {
+    override fun deleteOlderItems(transaction: KottageTransaction, itemType: String, limit: Long) {
         var deleted = 0L
-        itemRepository.getOlderKeys(itemType, null) { key ->
-            val itemListEntryIds = itemListRepository.getIds(itemType = itemType, itemKey = key)
+        itemRepository.getOlderKeys(transaction.transaction, itemType, null) { key ->
+            val itemListEntryIds = itemListRepository.getIds(transaction.transaction, itemType = itemType, itemKey = key)
             if (itemListEntryIds.isEmpty()) {
                 // ItemList に存在しなければ削除可能
-                deleteItemInternal(key, itemType)
+                deleteItemInternal(transaction.transaction, key, itemType)
                 deleted++
             }
             (deleted < limit)
         }
     }
 
-    override fun deleteExpiredItems(itemType: String, now: Long): Long {
+    override fun deleteExpiredItems(transaction: KottageTransaction, itemType: String, now: Long): Long {
         var deleted = 0L
         // List Invalidate を処理しておく
-        invalidateExpiredListEntries(now)
-        itemRepository.getExpiredKeys(now, itemType) { key, _ ->
-            val itemListEntryIds = itemListRepository.getIds(itemType = itemType, itemKey = key)
+        invalidateExpiredListEntries(transaction.transaction, now)
+        itemRepository.getExpiredKeys(transaction.transaction, now, itemType) { key, _ ->
+            val itemListEntryIds = itemListRepository.getIds(transaction.transaction, itemType = itemType, itemKey = key)
             if (itemListEntryIds.isEmpty()) {
                 // ItemList に存在しなければ削除可能
-                deleteItemInternal(key, itemType)
+                deleteItemInternal(transaction.transaction, key, itemType)
                 deleted++
             }
         }
@@ -371,16 +382,16 @@ internal class KottageOperator(
      *
      * ItemList の存在チェックなしで Item を削除する
      */
-    fun deleteItemInternal(key: String, itemType: String) {
-        itemRepository.delete(key, itemType)
-        itemRepository.decrementStatsCount(itemType, 1)
+    fun deleteItemInternal(transaction: Transaction, key: String, itemType: String) {
+        itemRepository.delete(transaction, key, itemType)
+        itemRepository.decrementStatsCount(transaction, itemType, 1)
     }
 
     /**
      * This should be called in transaction
      */
-    fun deleteItemStats(itemType: String) {
-        itemRepository.deleteStats(itemType = itemType)
+    fun deleteItemStats(transaction: Transaction, itemType: String) {
+        itemRepository.deleteStats(transaction, itemType = itemType)
     }
 
     /**
@@ -388,9 +399,9 @@ internal class KottageOperator(
      *
      * This should be called in transaction
      */
-    private fun deleteEvent(id: String, itemType: String) {
-        itemEventRepository.delete(id)
-        itemEventRepository.decrementStatsCount(itemType, 1)
+    private fun deleteEvent(transaction: Transaction, id: String, itemType: String) {
+        itemEventRepository.delete(transaction, id)
+        itemEventRepository.decrementStatsCount(transaction, itemType, 1)
     }
 
     /**
@@ -401,6 +412,7 @@ internal class KottageOperator(
      * @return event id
      */
     private fun addEventInternal(
+        transaction: Transaction,
         now: Long,
         eventExpireTime: Duration?,
         itemType: String,
@@ -410,12 +422,13 @@ internal class KottageOperator(
         eventType: ItemEventType
     ): String {
         val id = Id.generateUuidV4Short()
-        val latestCreatedAt = (itemEventRepository.getLatestCreatedAt(itemType) ?: 0)
+        val latestCreatedAt = (itemEventRepository.getLatestCreatedAt(transaction, itemType) ?: 0)
         val createdAt = now.coerceAtLeast(latestCreatedAt + 1)
         val expireAt = eventExpireTime?.let { duration ->
             (createdAt + duration.inWholeMilliseconds)
         }
         itemEventRepository.create(
+            transaction,
             ItemEvent(
                 id = id,
                 createdAt = createdAt,
@@ -433,20 +446,20 @@ internal class KottageOperator(
     /**
      * This should be called in transaction
      */
-    private fun reduceEvents(now: Long, itemType: String, maxEventEntryCount: Long) {
-        val currentCount = itemEventRepository.getStatsCount(itemType)
+    private fun reduceEvents(transaction: Transaction, now: Long, itemType: String, maxEventEntryCount: Long) {
+        val currentCount = itemEventRepository.getStatsCount(transaction, itemType)
         if (maxEventEntryCount < currentCount) {
             var deleted = 0L
-            itemEventRepository.getExpiredIds(now, itemType) { id, _ ->
-                deleteEvent(id, itemType)
+            itemEventRepository.getExpiredIds(transaction, now, itemType) { id, _ ->
+                deleteEvent(transaction, id, itemType)
                 deleted++
             }
             val calculatedReduceCount = (maxEventEntryCount * 0.25).toLong().coerceAtLeast(1)
             val reduceCount = calculatedReduceCount - deleted
             if (0 < reduceCount) {
-                itemEventRepository.deleteOlderEvents(itemType, reduceCount)
-                val count = itemEventRepository.getCount(itemType)
-                itemEventRepository.updateStatsCount(itemType, count)
+                itemEventRepository.deleteOlderEvents(transaction, itemType, reduceCount)
+                val count = itemEventRepository.getCount(transaction, itemType)
+                itemEventRepository.updateStatsCount(transaction, itemType, count)
             }
         }
     }

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageStorageImpl.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageStorageImpl.kt
@@ -8,6 +8,7 @@ import io.github.irgaly.kottage.KottageListOptions
 import io.github.irgaly.kottage.KottageOptions
 import io.github.irgaly.kottage.KottageStorage
 import io.github.irgaly.kottage.KottageStorageOptions
+import io.github.irgaly.kottage.internal.database.Transaction
 import io.github.irgaly.kottage.internal.encoder.Encoder
 import io.github.irgaly.kottage.internal.encoder.encodeItem
 import io.github.irgaly.kottage.internal.property.KottageStorageStore
@@ -264,7 +265,7 @@ internal class KottageStorageImpl(
 
     private suspend fun <R> transactionWithAutoCompaction(
         now: Long? = null,
-        bodyWithReturn: (operator: KottageOperator, now: Long) -> R
+        bodyWithReturn: Transaction.(operator: KottageOperator, now: Long) -> R
     ): R {
         val operator = operator()
         val receivedNow = now ?: calendar.nowUnixTimeMillis()

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageStorageImpl.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageStorageImpl.kt
@@ -267,7 +267,7 @@ internal class KottageStorageImpl(
 
     private suspend fun <R> transactionWithAutoCompaction(
         now: Long? = null,
-        bodyWithReturn: Transaction.(operator: KottageOperator, now: Long) -> R
+        bodyWithReturn: suspend Transaction.(operator: KottageOperator, now: Long) -> R
     ): R {
         val operator = operator()
         val receivedNow = now ?: calendar.nowUnixTimeMillis()

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageStorageOperator.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageStorageOperator.kt
@@ -26,7 +26,7 @@ internal class KottageStorageOperator(
     /**
      * This should be called in transaction
      */
-    fun upsertItem(transaction: Transaction, item: Item, now: Long) {
+    suspend fun upsertItem(transaction: Transaction, item: Item, now: Long) {
         val isCreate = !itemRepository.exists(transaction, item.key, item.type)
         itemRepository.upsert(transaction, item)
         if (isCreate) {
@@ -52,7 +52,7 @@ internal class KottageStorageOperator(
     /**
      * This should be called in transaction
      */
-    fun getOrNull(transaction: Transaction, key: String, now: Long?): Item? {
+    suspend fun getOrNull(transaction: Transaction, key: String, now: Long?): Item? {
         var item = itemRepository.get(transaction, key, itemType)
         if ((now != null) && (item != null) && item.isExpired(now)) {
             val itemListEntryIds = itemListRepository.getIds(transaction, itemType = itemType, itemKey = key)
@@ -68,7 +68,7 @@ internal class KottageStorageOperator(
     /**
      * This should be called in transaction
      */
-    fun getAllKeys(transaction: Transaction, receiver: (key: String) -> Unit) {
+    suspend fun getAllKeys(transaction: Transaction, receiver: suspend (key: String) -> Unit) {
         itemRepository.getAllKeys(transaction, itemType = itemType, receiver = receiver)
     }
 
@@ -79,7 +79,7 @@ internal class KottageStorageOperator(
      * * ItemList からも削除される
      * * ItemList / Item の Delete Event が登録される
      */
-    fun deleteItem(
+    suspend fun deleteItem(
         transaction: Transaction,
         key: String,
         now: Long,
@@ -130,14 +130,14 @@ internal class KottageStorageOperator(
     /**
      * This should be called in transaction
      */
-    fun exists(transaction: Transaction, key: String): Boolean {
+    suspend fun exists(transaction: Transaction, key: String): Boolean {
         return itemRepository.exists(transaction, key = key, itemType = itemType)
     }
 
     /**
      * This should be called in transaction
      */
-    fun clear(transaction: Transaction, now: Long) {
+    suspend fun clear(transaction: Transaction, now: Long) {
         itemRepository.getAllKeys(transaction, itemType) { key ->
             itemListRepository.getIds(
                 transaction,
@@ -162,7 +162,7 @@ internal class KottageStorageOperator(
     /**
      * This should be called in transaction
      */
-    fun removeListItemInternal(
+    suspend fun removeListItemInternal(
         transaction: Transaction,
         positionId: String,
         listType: String,
@@ -188,7 +188,7 @@ internal class KottageStorageOperator(
     /**
      * This should be called in transaction
      */
-    fun getDebugStatus(transaction: Transaction): String {
+    suspend fun getDebugStatus(transaction: Transaction): String {
         val stats = itemRepository.getStats(transaction, itemType)
         val count = itemRepository.getCount(transaction, itemType)
         return """

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/database/DatabaseConnection.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/database/DatabaseConnection.kt
@@ -8,12 +8,12 @@ internal expect class DatabaseConnection {
     /**
      * Exclusive Transaction
      */
-    suspend fun <R> transactionWithResult(bodyWithReturn: Transaction.() -> R): R
+    suspend fun <R> transactionWithResult(bodyWithReturn: suspend Transaction.() -> R): R
 
     /**
      * Exclusive Transaction
      */
-    suspend fun transaction(body: Transaction.() -> Unit)
+    suspend fun transaction(body: suspend Transaction.() -> Unit)
 
 
     /**

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/database/DatabaseConnection.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/database/DatabaseConnection.kt
@@ -8,12 +8,12 @@ internal expect class DatabaseConnection {
     /**
      * Exclusive Transaction
      */
-    suspend fun <R> transactionWithResult(bodyWithReturn: () -> R): R
+    suspend fun <R> transactionWithResult(bodyWithReturn: Transaction.() -> R): R
 
     /**
      * Exclusive Transaction
      */
-    suspend fun transaction(body: () -> Unit)
+    suspend fun transaction(body: Transaction.() -> Unit)
 
 
     /**

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/database/Transaction.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/database/Transaction.kt
@@ -1,0 +1,4 @@
+package io.github.irgaly.kottage.internal.database
+
+internal expect class Transaction {
+}

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageItemEventRepository.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageItemEventRepository.kt
@@ -1,30 +1,33 @@
 package io.github.irgaly.kottage.internal.repository
 
+import io.github.irgaly.kottage.internal.database.Transaction
 import io.github.irgaly.kottage.internal.model.ItemEvent
 
 internal interface KottageItemEventRepository {
-    fun create(itemEvent: ItemEvent)
+    fun create(transaction: Transaction, itemEvent: ItemEvent)
     fun selectAfter(
+        transaction: Transaction,
         createdAt: Long,
         itemType: String? = null,
-        limit: Long? = null,
+        limit: Long? = null
     ): List<ItemEvent>
 
-    fun getLatestCreatedAt(itemType: String): Long?
+    fun getLatestCreatedAt(transaction: Transaction, itemType: String): Long?
     fun getExpiredIds(
+        transaction: Transaction,
         now: Long,
         itemType: String? = null,
         receiver: (id: String, itemType: String) -> Unit
     )
 
-    fun getCount(itemType: String): Long
-    fun delete(id: String)
-    fun deleteOlderEvents(itemType: String, limit: Long)
-    fun deleteBefore(createdAt: Long)
-    fun deleteAll(itemType: String)
-    fun deleteAllList(listType: String)
-    fun getStatsCount(itemType: String): Long
-    fun incrementStatsCount(itemType: String, count: Long)
-    fun decrementStatsCount(itemType: String, count: Long)
-    fun updateStatsCount(itemType: String, count: Long)
+    fun getCount(transaction: Transaction, itemType: String): Long
+    fun delete(transaction: Transaction, id: String)
+    fun deleteOlderEvents(transaction: Transaction, itemType: String, limit: Long)
+    fun deleteBefore(transaction: Transaction, createdAt: Long)
+    fun deleteAll(transaction: Transaction, itemType: String)
+    fun deleteAllList(transaction: Transaction, listType: String)
+    fun getStatsCount(transaction: Transaction, itemType: String): Long
+    fun incrementStatsCount(transaction: Transaction, itemType: String, count: Long)
+    fun decrementStatsCount(transaction: Transaction, itemType: String, count: Long)
+    fun updateStatsCount(transaction: Transaction, itemType: String, count: Long)
 }

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageItemEventRepository.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageItemEventRepository.kt
@@ -13,15 +13,15 @@ internal interface KottageItemEventRepository {
     ): List<ItemEvent>
 
     suspend fun getLatestCreatedAt(transaction: Transaction, itemType: String): Long?
-    suspend fun getExpiredIds(
+    suspend fun getCount(transaction: Transaction, itemType: String): Long
+    suspend fun delete(transaction: Transaction, id: String)
+    suspend fun deleteExpiredEvents(
         transaction: Transaction,
         now: Long,
         itemType: String? = null,
-        receiver: suspend (id: String, itemType: String) -> Unit
-    )
+        onDelete: (suspend (id: String, itemType: String) -> Unit)? = null
+    ): Long
 
-    suspend fun getCount(transaction: Transaction, itemType: String): Long
-    suspend fun delete(transaction: Transaction, id: String)
     suspend fun deleteOlderEvents(transaction: Transaction, itemType: String, limit: Long)
     suspend fun deleteBefore(transaction: Transaction, createdAt: Long)
     suspend fun deleteAll(transaction: Transaction, itemType: String)

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageItemEventRepository.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageItemEventRepository.kt
@@ -4,30 +4,30 @@ import io.github.irgaly.kottage.internal.database.Transaction
 import io.github.irgaly.kottage.internal.model.ItemEvent
 
 internal interface KottageItemEventRepository {
-    fun create(transaction: Transaction, itemEvent: ItemEvent)
-    fun selectAfter(
+    suspend fun create(transaction: Transaction, itemEvent: ItemEvent)
+    suspend fun selectAfter(
         transaction: Transaction,
         createdAt: Long,
         itemType: String? = null,
         limit: Long? = null
     ): List<ItemEvent>
 
-    fun getLatestCreatedAt(transaction: Transaction, itemType: String): Long?
-    fun getExpiredIds(
+    suspend fun getLatestCreatedAt(transaction: Transaction, itemType: String): Long?
+    suspend fun getExpiredIds(
         transaction: Transaction,
         now: Long,
         itemType: String? = null,
-        receiver: (id: String, itemType: String) -> Unit
+        receiver: suspend (id: String, itemType: String) -> Unit
     )
 
-    fun getCount(transaction: Transaction, itemType: String): Long
-    fun delete(transaction: Transaction, id: String)
-    fun deleteOlderEvents(transaction: Transaction, itemType: String, limit: Long)
-    fun deleteBefore(transaction: Transaction, createdAt: Long)
-    fun deleteAll(transaction: Transaction, itemType: String)
-    fun deleteAllList(transaction: Transaction, listType: String)
-    fun getStatsCount(transaction: Transaction, itemType: String): Long
-    fun incrementStatsCount(transaction: Transaction, itemType: String, count: Long)
-    fun decrementStatsCount(transaction: Transaction, itemType: String, count: Long)
-    fun updateStatsCount(transaction: Transaction, itemType: String, count: Long)
+    suspend fun getCount(transaction: Transaction, itemType: String): Long
+    suspend fun delete(transaction: Transaction, id: String)
+    suspend fun deleteOlderEvents(transaction: Transaction, itemType: String, limit: Long)
+    suspend fun deleteBefore(transaction: Transaction, createdAt: Long)
+    suspend fun deleteAll(transaction: Transaction, itemType: String)
+    suspend fun deleteAllList(transaction: Transaction, listType: String)
+    suspend fun getStatsCount(transaction: Transaction, itemType: String): Long
+    suspend fun incrementStatsCount(transaction: Transaction, itemType: String, count: Long)
+    suspend fun decrementStatsCount(transaction: Transaction, itemType: String, count: Long)
+    suspend fun updateStatsCount(transaction: Transaction, itemType: String, count: Long)
 }

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageItemListRepository.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageItemListRepository.kt
@@ -5,10 +5,10 @@ import io.github.irgaly.kottage.internal.model.ItemListEntry
 import io.github.irgaly.kottage.internal.model.ItemListStats
 
 internal interface KottageItemListRepository {
-    fun upsert(transaction: Transaction, entry: ItemListEntry)
-    fun updatePreviousId(transaction: Transaction, id: String, previousId: String?)
-    fun updateNextId(transaction: Transaction, id: String, nextId: String?)
-    fun updateItemKey(
+    suspend fun upsert(transaction: Transaction, entry: ItemListEntry)
+    suspend fun updatePreviousId(transaction: Transaction, id: String, previousId: String?)
+    suspend fun updateNextId(transaction: Transaction, id: String, nextId: String?)
+    suspend fun updateItemKey(
         transaction: Transaction,
         id: String,
         itemType: String,
@@ -16,28 +16,28 @@ internal interface KottageItemListRepository {
         expireAt: Long?
     )
 
-    fun updateExpireAt(transaction: Transaction, id: String, expireAt: Long?)
-    fun removeItemKey(transaction: Transaction, id: String)
-    fun removeUserData(transaction: Transaction, id: String)
-    fun get(transaction: Transaction, id: String): ItemListEntry?
-    fun getIds(transaction: Transaction, itemType: String, itemKey: String): List<String>
-    fun getInvalidatedItemIds(
+    suspend fun updateExpireAt(transaction: Transaction, id: String, expireAt: Long?)
+    suspend fun removeItemKey(transaction: Transaction, id: String)
+    suspend fun removeUserData(transaction: Transaction, id: String)
+    suspend fun get(transaction: Transaction, id: String): ItemListEntry?
+    suspend fun getIds(transaction: Transaction, itemType: String, itemKey: String): List<String>
+    suspend fun getInvalidatedItemIds(
         transaction: Transaction,
         type: String,
         beforeExpireAt: Long?,
         limit: Long
     ): List<String>
 
-    fun getCount(transaction: Transaction, type: String): Long
-    fun getInvalidatedItemCount(transaction: Transaction, type: String): Long
-    fun getAllTypes(
+    suspend fun getCount(transaction: Transaction, type: String): Long
+    suspend fun getInvalidatedItemCount(transaction: Transaction, type: String): Long
+    suspend fun getAllTypes(
         transaction: Transaction,
-        receiver: (type: String) -> Unit
+        receiver: suspend (type: String) -> Unit
     )
 
-    fun delete(transaction: Transaction, id: String)
-    fun deleteAll(transaction: Transaction, type: String)
-    fun createStats(
+    suspend fun delete(transaction: Transaction, id: String)
+    suspend fun deleteAll(transaction: Transaction, type: String)
+    suspend fun createStats(
         transaction: Transaction,
         type: String,
         count: Long,
@@ -45,12 +45,12 @@ internal interface KottageItemListRepository {
         lastItemListEntryId: String
     )
 
-    fun getStats(transaction: Transaction, type: String): ItemListStats?
-    fun getStatsCount(transaction: Transaction, type: String): Long
-    fun incrementStatsCount(transaction: Transaction, type: String, count: Long)
-    fun decrementStatsCount(transaction: Transaction, type: String, count: Long)
-    fun updateStatsCount(transaction: Transaction, type: String, count: Long)
-    fun updateStatsFirstItem(transaction: Transaction, type: String, id: String)
-    fun updateStatsLastItem(transaction: Transaction, type: String, id: String)
-    fun deleteStats(transaction: Transaction, type: String)
+    suspend fun getStats(transaction: Transaction, type: String): ItemListStats?
+    suspend fun getStatsCount(transaction: Transaction, type: String): Long
+    suspend fun incrementStatsCount(transaction: Transaction, type: String, count: Long)
+    suspend fun decrementStatsCount(transaction: Transaction, type: String, count: Long)
+    suspend fun updateStatsCount(transaction: Transaction, type: String, count: Long)
+    suspend fun updateStatsFirstItem(transaction: Transaction, type: String, id: String)
+    suspend fun updateStatsLastItem(transaction: Transaction, type: String, id: String)
+    suspend fun deleteStats(transaction: Transaction, type: String)
 }

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageItemListRepository.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageItemListRepository.kt
@@ -1,37 +1,56 @@
 package io.github.irgaly.kottage.internal.repository
 
+import io.github.irgaly.kottage.internal.database.Transaction
 import io.github.irgaly.kottage.internal.model.ItemListEntry
 import io.github.irgaly.kottage.internal.model.ItemListStats
 
 internal interface KottageItemListRepository {
-    fun upsert(entry: ItemListEntry)
-    fun updatePreviousId(id: String, previousId: String?)
-    fun updateNextId(id: String, nextId: String?)
-    fun updateItemKey(id: String, itemType: String, itemKey: String?, expireAt: Long?)
-    fun updateExpireAt(id: String, expireAt: Long?)
-    fun removeItemKey(id: String)
-    fun removeUserData(id: String)
-    fun get(id: String): ItemListEntry?
-    fun getIds(itemType: String, itemKey: String): List<String>
-    fun getInvalidatedItemIds(type: String, beforeExpireAt: Long?, limit: Long): List<String>
-    fun getCount(type: String): Long
-    fun getInvalidatedItemCount(type: String): Long
-    fun getAllTypes(receiver: (type: String) -> Unit)
-    fun delete(id: String)
-    fun deleteAll(type: String)
+    fun upsert(transaction: Transaction, entry: ItemListEntry)
+    fun updatePreviousId(transaction: Transaction, id: String, previousId: String?)
+    fun updateNextId(transaction: Transaction, id: String, nextId: String?)
+    fun updateItemKey(
+        transaction: Transaction,
+        id: String,
+        itemType: String,
+        itemKey: String?,
+        expireAt: Long?
+    )
+
+    fun updateExpireAt(transaction: Transaction, id: String, expireAt: Long?)
+    fun removeItemKey(transaction: Transaction, id: String)
+    fun removeUserData(transaction: Transaction, id: String)
+    fun get(transaction: Transaction, id: String): ItemListEntry?
+    fun getIds(transaction: Transaction, itemType: String, itemKey: String): List<String>
+    fun getInvalidatedItemIds(
+        transaction: Transaction,
+        type: String,
+        beforeExpireAt: Long?,
+        limit: Long
+    ): List<String>
+
+    fun getCount(transaction: Transaction, type: String): Long
+    fun getInvalidatedItemCount(transaction: Transaction, type: String): Long
+    fun getAllTypes(
+        transaction: Transaction,
+        receiver: (type: String) -> Unit
+    )
+
+    fun delete(transaction: Transaction, id: String)
+    fun deleteAll(transaction: Transaction, type: String)
     fun createStats(
+        transaction: Transaction,
         type: String,
         count: Long,
         firstItemListEntryId: String,
         lastItemListEntryId: String
     )
 
-    fun getStats(type: String): ItemListStats?
-    fun getStatsCount(type: String): Long
-    fun incrementStatsCount(type: String, count: Long)
-    fun decrementStatsCount(type: String, count: Long)
-    fun updateStatsCount(type: String, count: Long)
-    fun updateStatsFirstItem(type: String, id: String)
-    fun updateStatsLastItem(type: String, id: String)
-    fun deleteStats(type: String)
+    fun getStats(transaction: Transaction, type: String): ItemListStats?
+    fun getStatsCount(transaction: Transaction, type: String): Long
+    fun incrementStatsCount(transaction: Transaction, type: String, count: Long)
+    fun decrementStatsCount(transaction: Transaction, type: String, count: Long)
+    fun updateStatsCount(transaction: Transaction, type: String, count: Long)
+    fun updateStatsFirstItem(transaction: Transaction, type: String, id: String)
+    fun updateStatsLastItem(transaction: Transaction, type: String, id: String)
+    fun deleteStats(transaction: Transaction, type: String)
 }

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageItemRepository.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageItemRepository.kt
@@ -1,42 +1,51 @@
 package io.github.irgaly.kottage.internal.repository
 
+import io.github.irgaly.kottage.internal.database.Transaction
 import io.github.irgaly.kottage.internal.model.Item
 import io.github.irgaly.kottage.internal.model.ItemStats
 
 internal interface KottageItemRepository {
-    fun upsert(item: Item)
-    fun updateLastRead(key: String, itemType: String, lastReadAt: Long)
-    fun updateExpireAt(key: String, itemType: String, expireAt: Long)
-    fun exists(key: String, itemType: String): Boolean
-    fun get(key: String, itemType: String): Item?
-    fun getCount(itemType: String): Long
-    fun getAllKeys(itemType: String, receiver: (key: String) -> Unit)
+    fun upsert(transaction: Transaction, item: Item)
+    fun updateLastRead(transaction: Transaction, key: String, itemType: String, lastReadAt: Long)
+    fun updateExpireAt(transaction: Transaction, key: String, itemType: String, expireAt: Long)
+    fun exists(transaction: Transaction, key: String, itemType: String): Boolean
+    fun get(transaction: Transaction, key: String, itemType: String): Item?
+    fun getCount(transaction: Transaction, itemType: String): Long
+    fun getAllKeys(
+        transaction: Transaction,
+        itemType: String,
+        receiver: (key: String) -> Unit
+    )
+
     fun getExpiredKeys(
+        transaction: Transaction,
         now: Long,
         itemType: String? = null,
         receiver: (key: String, itemType: String) -> Unit
     )
 
     fun getLeastRecentlyUsedKeys(
+        transaction: Transaction,
         itemType: String,
         limit: Long?,
         receiver: (key: String) -> Boolean
     )
 
     fun getOlderKeys(
+        transaction: Transaction,
         itemType: String,
         limit: Long?,
         receiver: (key: String) -> Boolean
     )
 
-    fun getStats(itemType: String): ItemStats?
-    fun getEmptyStats(limit: Long): List<ItemStats>
+    fun getStats(transaction: Transaction, itemType: String): ItemStats?
+    fun getEmptyStats(transaction: Transaction, limit: Long): List<ItemStats>
 
-    fun delete(key: String, itemType: String)
-    fun deleteAll(itemType: String)
-    fun getStatsCount(itemType: String): Long
-    fun incrementStatsCount(itemType: String, count: Long)
-    fun decrementStatsCount(itemType: String, count: Long)
-    fun updateStatsCount(itemType: String, count: Long)
-    fun deleteStats(itemType: String)
+    fun delete(transaction: Transaction, key: String, itemType: String)
+    fun deleteAll(transaction: Transaction, itemType: String)
+    fun getStatsCount(transaction: Transaction, itemType: String): Long
+    fun incrementStatsCount(transaction: Transaction, itemType: String, count: Long)
+    fun decrementStatsCount(transaction: Transaction, itemType: String, count: Long)
+    fun updateStatsCount(transaction: Transaction, itemType: String, count: Long)
+    fun deleteStats(transaction: Transaction, itemType: String)
 }

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageItemRepository.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageItemRepository.kt
@@ -5,47 +5,47 @@ import io.github.irgaly.kottage.internal.model.Item
 import io.github.irgaly.kottage.internal.model.ItemStats
 
 internal interface KottageItemRepository {
-    fun upsert(transaction: Transaction, item: Item)
-    fun updateLastRead(transaction: Transaction, key: String, itemType: String, lastReadAt: Long)
-    fun updateExpireAt(transaction: Transaction, key: String, itemType: String, expireAt: Long)
-    fun exists(transaction: Transaction, key: String, itemType: String): Boolean
-    fun get(transaction: Transaction, key: String, itemType: String): Item?
-    fun getCount(transaction: Transaction, itemType: String): Long
-    fun getAllKeys(
+    suspend fun upsert(transaction: Transaction, item: Item)
+    suspend fun updateLastRead(transaction: Transaction, key: String, itemType: String, lastReadAt: Long)
+    suspend fun updateExpireAt(transaction: Transaction, key: String, itemType: String, expireAt: Long)
+    suspend fun exists(transaction: Transaction, key: String, itemType: String): Boolean
+    suspend fun get(transaction: Transaction, key: String, itemType: String): Item?
+    suspend fun getCount(transaction: Transaction, itemType: String): Long
+    suspend fun getAllKeys(
         transaction: Transaction,
         itemType: String,
-        receiver: (key: String) -> Unit
+        receiver: suspend (key: String) -> Unit
     )
 
-    fun getExpiredKeys(
+    suspend fun getExpiredKeys(
         transaction: Transaction,
         now: Long,
         itemType: String? = null,
-        receiver: (key: String, itemType: String) -> Unit
+        receiver: suspend (key: String, itemType: String) -> Unit
     )
 
-    fun getLeastRecentlyUsedKeys(
+    suspend fun getLeastRecentlyUsedKeys(
         transaction: Transaction,
         itemType: String,
         limit: Long?,
-        receiver: (key: String) -> Boolean
+        receiver: suspend (key: String) -> Boolean
     )
 
-    fun getOlderKeys(
+    suspend fun getOlderKeys(
         transaction: Transaction,
         itemType: String,
         limit: Long?,
-        receiver: (key: String) -> Boolean
+        receiver: suspend (key: String) -> Boolean
     )
 
-    fun getStats(transaction: Transaction, itemType: String): ItemStats?
-    fun getEmptyStats(transaction: Transaction, limit: Long): List<ItemStats>
+    suspend fun getStats(transaction: Transaction, itemType: String): ItemStats?
+    suspend fun getEmptyStats(transaction: Transaction, limit: Long): List<ItemStats>
 
-    fun delete(transaction: Transaction, key: String, itemType: String)
-    fun deleteAll(transaction: Transaction, itemType: String)
-    fun getStatsCount(transaction: Transaction, itemType: String): Long
-    fun incrementStatsCount(transaction: Transaction, itemType: String, count: Long)
-    fun decrementStatsCount(transaction: Transaction, itemType: String, count: Long)
-    fun updateStatsCount(transaction: Transaction, itemType: String, count: Long)
-    fun deleteStats(transaction: Transaction, itemType: String)
+    suspend fun delete(transaction: Transaction, key: String, itemType: String)
+    suspend fun deleteAll(transaction: Transaction, itemType: String)
+    suspend fun getStatsCount(transaction: Transaction, itemType: String): Long
+    suspend fun incrementStatsCount(transaction: Transaction, itemType: String, count: Long)
+    suspend fun decrementStatsCount(transaction: Transaction, itemType: String, count: Long)
+    suspend fun updateStatsCount(transaction: Transaction, itemType: String, count: Long)
+    suspend fun deleteStats(transaction: Transaction, itemType: String)
 }

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageStatsRepository.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageStatsRepository.kt
@@ -12,10 +12,10 @@ internal interface KottageStatsRepository {
     /**
      * get last evicting time
      */
-    fun getLastEvictAt(transaction: Transaction): Long
+    suspend fun getLastEvictAt(transaction: Transaction): Long
 
     /**
      * set last evicting time
      */
-    fun updateLastEvictAt(transaction: Transaction, now: Long)
+    suspend fun updateLastEvictAt(transaction: Transaction, now: Long)
 }

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageStatsRepository.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageStatsRepository.kt
@@ -1,5 +1,7 @@
 package io.github.irgaly.kottage.internal.repository
 
+import io.github.irgaly.kottage.internal.database.Transaction
+
 /**
  * stats Table
  *
@@ -10,9 +12,10 @@ internal interface KottageStatsRepository {
     /**
      * get last evicting time
      */
-    fun getLastEvictAt(): Long
+    fun getLastEvictAt(transaction: Transaction): Long
+
     /**
      * set last evicting time
      */
-    fun updateLastEvictAt(now: Long)
+    fun updateLastEvictAt(transaction: Transaction, now: Long)
 }

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/strategy/KottageFifoStrategy.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/strategy/KottageFifoStrategy.kt
@@ -14,6 +14,7 @@ class KottageFifoStrategy(
         (maxEntryCount * 0.25).toLong().coerceAtLeast(1)
 
     override fun onItemRead(
+        transaction: KottageTransaction,
         key: String,
         itemType: String,
         now: Long,
@@ -23,6 +24,7 @@ class KottageFifoStrategy(
     }
 
     override fun onPostItemCreate(
+        transaction: KottageTransaction,
         key: String,
         itemType: String,
         itemCount: Long,
@@ -31,11 +33,11 @@ class KottageFifoStrategy(
     ) {
         if (maxEntryCount < itemCount) {
             // expire caches
-            val expiredItemsCount = operator.deleteExpiredItems(itemType, now)
+            val expiredItemsCount = operator.deleteExpiredItems(transaction, itemType, now)
             // reduce caches
             val reduceCount = (reduceCount ?: calculatedReduceCount) - expiredItemsCount
             if (0 < reduceCount) {
-                operator.deleteOlderItems(itemType, reduceCount)
+                operator.deleteOlderItems(transaction, itemType, reduceCount)
             }
         }
     }

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/strategy/KottageFifoStrategy.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/strategy/KottageFifoStrategy.kt
@@ -13,7 +13,7 @@ class KottageFifoStrategy(
     private val calculatedReduceCount: Long =
         (maxEntryCount * 0.25).toLong().coerceAtLeast(1)
 
-    override fun onItemRead(
+    override suspend fun onItemRead(
         transaction: KottageTransaction,
         key: String,
         itemType: String,
@@ -23,7 +23,7 @@ class KottageFifoStrategy(
         // do nothing
     }
 
-    override fun onPostItemCreate(
+    override suspend fun onPostItemCreate(
         transaction: KottageTransaction,
         key: String,
         itemType: String,

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/strategy/KottageKvsStrategy.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/strategy/KottageKvsStrategy.kt
@@ -4,7 +4,7 @@ package io.github.irgaly.kottage.strategy
  * No Eviction Strategy
  */
 class KottageKvsStrategy : KottageStrategy {
-    override fun onItemRead(
+    override suspend fun onItemRead(
         transaction: KottageTransaction,
         key: String,
         itemType: String,
@@ -14,7 +14,7 @@ class KottageKvsStrategy : KottageStrategy {
         // do nothing
     }
 
-    override fun onPostItemCreate(
+    override suspend fun onPostItemCreate(
         transaction: KottageTransaction,
         key: String,
         itemType: String,

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/strategy/KottageKvsStrategy.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/strategy/KottageKvsStrategy.kt
@@ -5,6 +5,7 @@ package io.github.irgaly.kottage.strategy
  */
 class KottageKvsStrategy : KottageStrategy {
     override fun onItemRead(
+        transaction: KottageTransaction,
         key: String,
         itemType: String,
         now: Long,
@@ -14,6 +15,7 @@ class KottageKvsStrategy : KottageStrategy {
     }
 
     override fun onPostItemCreate(
+        transaction: KottageTransaction,
         key: String,
         itemType: String,
         itemCount: Long,

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/strategy/KottageLruStrategy.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/strategy/KottageLruStrategy.kt
@@ -13,7 +13,7 @@ class KottageLruStrategy(
     private val calculatedReduceCount: Long =
         (maxEntryCount * 0.25).toLong().coerceAtLeast(1)
 
-    override fun onItemRead(
+    override suspend fun onItemRead(
         transaction: KottageTransaction,
         key: String,
         itemType: String,
@@ -23,7 +23,7 @@ class KottageLruStrategy(
         operator.updateItemLastRead(transaction, key, itemType, now)
     }
 
-    override fun onPostItemCreate(
+    override suspend fun onPostItemCreate(
         transaction: KottageTransaction,
         key: String,
         itemType: String,

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/strategy/KottageLruStrategy.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/strategy/KottageLruStrategy.kt
@@ -14,15 +14,17 @@ class KottageLruStrategy(
         (maxEntryCount * 0.25).toLong().coerceAtLeast(1)
 
     override fun onItemRead(
+        transaction: KottageTransaction,
         key: String,
         itemType: String,
         now: Long,
         operator: KottageStrategyOperator
     ) {
-        operator.updateItemLastRead(key, itemType, now)
+        operator.updateItemLastRead(transaction, key, itemType, now)
     }
 
     override fun onPostItemCreate(
+        transaction: KottageTransaction,
         key: String,
         itemType: String,
         itemCount: Long,
@@ -31,11 +33,11 @@ class KottageLruStrategy(
     ) {
         if (maxEntryCount < itemCount) {
             // expire caches
-            val expiredItemsCount = operator.deleteExpiredItems(itemType, now)
+            val expiredItemsCount = operator.deleteExpiredItems(transaction, itemType, now)
             // reduce caches
             val reduceCount = (reduceCount ?: calculatedReduceCount) - expiredItemsCount
             if (0 < reduceCount) {
-                operator.deleteLeastRecentlyUsed(itemType, reduceCount)
+                operator.deleteLeastRecentlyUsed(transaction, itemType, reduceCount)
             }
         }
     }

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/strategy/KottageStrategy.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/strategy/KottageStrategy.kt
@@ -4,7 +4,7 @@ interface KottageStrategy {
     /**
      * called in transaction
      */
-    fun onItemRead(
+    suspend fun onItemRead(
         transaction: KottageTransaction,
         key: String,
         itemType: String,
@@ -14,7 +14,7 @@ interface KottageStrategy {
     /**
      * called in transaction
      */
-    fun onPostItemCreate(
+    suspend fun onPostItemCreate(
         transaction: KottageTransaction,
         key: String,
         itemType: String,

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/strategy/KottageStrategy.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/strategy/KottageStrategy.kt
@@ -4,12 +4,18 @@ interface KottageStrategy {
     /**
      * called in transaction
      */
-    fun onItemRead(key: String, itemType: String, now: Long, operator: KottageStrategyOperator)
+    fun onItemRead(
+        transaction: KottageTransaction,
+        key: String,
+        itemType: String,
+        now: Long, operator: KottageStrategyOperator
+    )
 
     /**
      * called in transaction
      */
     fun onPostItemCreate(
+        transaction: KottageTransaction,
         key: String,
         itemType: String,
         itemCount: Long,

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/strategy/KottageStrategyOperator.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/strategy/KottageStrategyOperator.kt
@@ -4,21 +4,21 @@ interface KottageStrategyOperator {
     /**
      * This should be called in transaction
      */
-    fun updateItemLastRead(key: String, itemType: String, now: Long)
+    fun updateItemLastRead(transaction: KottageTransaction, key: String, itemType: String, now: Long)
 
     /**
      * delete least recently used items
      * existing items in ItemList are ignored
      * This should be called in transaction
      */
-    fun deleteLeastRecentlyUsed(itemType: String, limit: Long)
+    fun deleteLeastRecentlyUsed(transaction: KottageTransaction, itemType: String, limit: Long)
 
     /**
      * delete older created items
      * existing items in ItemList are ignored
      * This should be called in transaction
      */
-    fun deleteOlderItems(itemType: String, limit: Long)
+    fun deleteOlderItems(transaction: KottageTransaction, itemType: String, limit: Long)
 
     /**
      * delete expired items
@@ -27,5 +27,5 @@ interface KottageStrategyOperator {
      *
      * @return deleted items count
      */
-    fun deleteExpiredItems(itemType: String, now: Long): Long
+    fun deleteExpiredItems(transaction: KottageTransaction, itemType: String, now: Long): Long
 }

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/strategy/KottageStrategyOperator.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/strategy/KottageStrategyOperator.kt
@@ -4,21 +4,21 @@ interface KottageStrategyOperator {
     /**
      * This should be called in transaction
      */
-    fun updateItemLastRead(transaction: KottageTransaction, key: String, itemType: String, now: Long)
+    suspend fun updateItemLastRead(transaction: KottageTransaction, key: String, itemType: String, now: Long)
 
     /**
      * delete least recently used items
      * existing items in ItemList are ignored
      * This should be called in transaction
      */
-    fun deleteLeastRecentlyUsed(transaction: KottageTransaction, itemType: String, limit: Long)
+    suspend fun deleteLeastRecentlyUsed(transaction: KottageTransaction, itemType: String, limit: Long)
 
     /**
      * delete older created items
      * existing items in ItemList are ignored
      * This should be called in transaction
      */
-    fun deleteOlderItems(transaction: KottageTransaction, itemType: String, limit: Long)
+    suspend fun deleteOlderItems(transaction: KottageTransaction, itemType: String, limit: Long)
 
     /**
      * delete expired items
@@ -27,5 +27,5 @@ interface KottageStrategyOperator {
      *
      * @return deleted items count
      */
-    fun deleteExpiredItems(transaction: KottageTransaction, itemType: String, now: Long): Long
+    suspend fun deleteExpiredItems(transaction: KottageTransaction, itemType: String, now: Long): Long
 }

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/strategy/KottageTransaction.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/strategy/KottageTransaction.kt
@@ -1,0 +1,13 @@
+package io.github.irgaly.kottage.strategy
+
+import io.github.irgaly.kottage.internal.database.Transaction
+import kotlin.jvm.JvmInline
+
+/**
+ * Kottage Transaction
+ */
+@JvmInline
+value class KottageTransaction internal constructor(
+    // internal class の Transaction を外部に露出するために value class で包んでいる
+    internal val transaction: Transaction
+)

--- a/kottage/src/commonSqliteMain/kotlin/io/github/irgaly/kottage/internal/database/DatabaseConnection.kt
+++ b/kottage/src/commonSqliteMain/kotlin/io/github/irgaly/kottage/internal/database/DatabaseConnection.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 internal actual data class DatabaseConnection(
@@ -36,7 +37,7 @@ internal actual data class DatabaseConnection(
         return body(sqlDriver.await(), database.await())
     }
 
-    actual suspend fun <R> transactionWithResult(bodyWithReturn: Transaction.() -> R): R =
+    actual suspend fun <R> transactionWithResult(bodyWithReturn: suspend Transaction.() -> R): R =
         withContext(dispatcher) {
             withDatabase { sqlDriver, database ->
                 database.transactionWithResult {
@@ -44,19 +45,40 @@ internal actual data class DatabaseConnection(
                     // restart transaction with EXCLUSIVE
                     sqlDriver.execute(null, "END", 0)
                     sqlDriver.execute(null, "BEGIN EXCLUSIVE", 0)
-                    bodyWithReturn(Transaction())
+                    var result: R? = null
+                    var finished = false
+                    launch(start = CoroutineStart.UNDISPATCHED) {
+                        // SQLite Transaction はスレッド切り替えなしで実行する
+                        result = bodyWithReturn(Transaction())
+                        finished = true
+                    }
+                    if (!finished) {
+                        // スレッド切り替えなしで実行されたことを保証する
+                        error("database transaction invalid thread error")
+                    }
+                    @Suppress("UNCHECKED_CAST")
+                    result as R
                 }
             }
         }
 
-    actual suspend fun transaction(body: Transaction.() -> Unit) = withContext(dispatcher) {
+    actual suspend fun transaction(body: suspend Transaction.() -> Unit) = withContext(dispatcher) {
         withDatabase { sqlDriver, database ->
             database.transaction {
                 // here: SQLDelight Transaction = DEFERRED (default)
                 // restart transaction with EXCLUSIVE
                 sqlDriver.execute(null, "END", 0)
                 sqlDriver.execute(null, "BEGIN EXCLUSIVE", 0)
-                body(Transaction())
+                var finished = false
+                launch(start = CoroutineStart.UNDISPATCHED) {
+                    // SQLite Transaction はスレッド切り替えなしで実行する
+                    body(Transaction())
+                    finished = true
+                }
+                if (!finished) {
+                    // スレッド切り替えなしで実行されたことを保証する
+                    error("database transaction invalid thread error")
+                }
             }
         }
     }

--- a/kottage/src/commonSqliteMain/kotlin/io/github/irgaly/kottage/internal/database/Transaction.kt
+++ b/kottage/src/commonSqliteMain/kotlin/io/github/irgaly/kottage/internal/database/Transaction.kt
@@ -1,0 +1,3 @@
+package io.github.irgaly.kottage.internal.database
+
+internal actual class Transaction

--- a/kottage/src/commonSqliteMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageSqliteItemEventRepository.kt
+++ b/kottage/src/commonSqliteMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageSqliteItemEventRepository.kt
@@ -2,17 +2,19 @@ package io.github.irgaly.kottage.internal.repository
 
 import com.squareup.sqldelight.db.use
 import io.github.irgaly.kottage.data.sqlite.KottageDatabase
+import io.github.irgaly.kottage.internal.database.Transaction
 import io.github.irgaly.kottage.internal.model.ItemEvent
 
 internal class KottageSqliteItemEventRepository(
     private val database: KottageDatabase
 ) : KottageItemEventRepository {
-    override fun create(itemEvent: ItemEvent) {
+    override fun create(transaction: Transaction, itemEvent: ItemEvent) {
         database.item_eventQueries
             .insert(itemEvent.toEntity())
     }
 
     override fun selectAfter(
+        transaction: Transaction,
         createdAt: Long,
         itemType: String?,
         limit: Long?
@@ -50,13 +52,14 @@ internal class KottageSqliteItemEventRepository(
         }
     }
 
-    override fun getLatestCreatedAt(itemType: String): Long? {
+    override fun getLatestCreatedAt(transaction: Transaction, itemType: String): Long? {
         return database.item_eventQueries
             .selectItemTypeLatestCreatedAt(itemType)
             .executeAsOneOrNull()
     }
 
     override fun getExpiredIds(
+        transaction: Transaction,
         now: Long,
         itemType: String?,
         receiver: (id: String, itemType: String) -> Unit
@@ -83,18 +86,18 @@ internal class KottageSqliteItemEventRepository(
         }
     }
 
-    override fun getCount(itemType: String): Long {
+    override fun getCount(transaction: Transaction, itemType: String): Long {
         return database.item_eventQueries
             .countByType(itemType)
             .executeAsOne()
     }
 
-    override fun delete(id: String) {
+    override fun delete(transaction: Transaction, id: String) {
         database.item_eventQueries
             .delete(id)
     }
 
-    override fun deleteOlderEvents(itemType: String, limit: Long) {
+    override fun deleteOlderEvents(transaction: Transaction, itemType: String, limit: Long) {
         database.item_eventQueries
             .selectOlderCreatedIds(itemType, limit)
             .execute().use { cursor ->
@@ -106,42 +109,42 @@ internal class KottageSqliteItemEventRepository(
             }
     }
 
-    override fun deleteBefore(createdAt: Long) {
+    override fun deleteBefore(transaction: Transaction, createdAt: Long) {
         database.item_eventQueries
             .deleteBefore(createdAt)
     }
 
-    override fun deleteAll(itemType: String) {
+    override fun deleteAll(transaction: Transaction, itemType: String) {
         database.item_eventQueries
             .deleteAllByType(itemType)
     }
 
-    override fun deleteAllList(listType: String) {
+    override fun deleteAllList(transaction: Transaction, listType: String) {
         database.item_eventQueries
             .deleteAllByListType(item_list_type = listType)
     }
 
-    override fun getStatsCount(itemType: String): Long {
+    override fun getStatsCount(transaction: Transaction, itemType: String): Long {
         return database.item_statsQueries
             .select(itemType)
             .executeAsOneOrNull()?.event_count ?: 0
     }
 
-    override fun incrementStatsCount(itemType: String, count: Long) {
+    override fun incrementStatsCount(transaction: Transaction, itemType: String, count: Long) {
         database.item_statsQueries
             .insertIfNotExists(itemType)
         database.item_statsQueries
             .incrementEventCount(count, itemType)
     }
 
-    override fun decrementStatsCount(itemType: String, count: Long) {
+    override fun decrementStatsCount(transaction: Transaction, itemType: String, count: Long) {
         database.item_statsQueries
             .insertIfNotExists(itemType)
         database.item_statsQueries
             .decrementEventCount(count, itemType)
     }
 
-    override fun updateStatsCount(itemType: String, count: Long) {
+    override fun updateStatsCount(transaction: Transaction, itemType: String, count: Long) {
         database.item_statsQueries
             .insertIfNotExists(itemType)
         database.item_statsQueries

--- a/kottage/src/commonSqliteMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageSqliteItemEventRepository.kt
+++ b/kottage/src/commonSqliteMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageSqliteItemEventRepository.kt
@@ -127,7 +127,7 @@ internal class KottageSqliteItemEventRepository(
     override suspend fun getStatsCount(transaction: Transaction, itemType: String): Long {
         return database.item_statsQueries
             .select(itemType)
-            .executeAsOneOrNull()?.event_count ?: 0
+            .executeAsOneOrNull()?.event_count ?: 0L
     }
 
     override suspend fun incrementStatsCount(transaction: Transaction, itemType: String, count: Long) {

--- a/kottage/src/commonSqliteMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageSqliteItemEventRepository.kt
+++ b/kottage/src/commonSqliteMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageSqliteItemEventRepository.kt
@@ -8,12 +8,12 @@ import io.github.irgaly.kottage.internal.model.ItemEvent
 internal class KottageSqliteItemEventRepository(
     private val database: KottageDatabase
 ) : KottageItemEventRepository {
-    override fun create(transaction: Transaction, itemEvent: ItemEvent) {
+    override suspend fun create(transaction: Transaction, itemEvent: ItemEvent) {
         database.item_eventQueries
             .insert(itemEvent.toEntity())
     }
 
-    override fun selectAfter(
+    override suspend fun selectAfter(
         transaction: Transaction,
         createdAt: Long,
         itemType: String?,
@@ -52,17 +52,17 @@ internal class KottageSqliteItemEventRepository(
         }
     }
 
-    override fun getLatestCreatedAt(transaction: Transaction, itemType: String): Long? {
+    override suspend fun getLatestCreatedAt(transaction: Transaction, itemType: String): Long? {
         return database.item_eventQueries
             .selectItemTypeLatestCreatedAt(itemType)
             .executeAsOneOrNull()
     }
 
-    override fun getExpiredIds(
+    override suspend fun getExpiredIds(
         transaction: Transaction,
         now: Long,
         itemType: String?,
-        receiver: (id: String, itemType: String) -> Unit
+        receiver: suspend (id: String, itemType: String) -> Unit
     ) {
         if (itemType != null) {
             database.item_eventQueries
@@ -86,18 +86,18 @@ internal class KottageSqliteItemEventRepository(
         }
     }
 
-    override fun getCount(transaction: Transaction, itemType: String): Long {
+    override suspend fun getCount(transaction: Transaction, itemType: String): Long {
         return database.item_eventQueries
             .countByType(itemType)
             .executeAsOne()
     }
 
-    override fun delete(transaction: Transaction, id: String) {
+    override suspend fun delete(transaction: Transaction, id: String) {
         database.item_eventQueries
             .delete(id)
     }
 
-    override fun deleteOlderEvents(transaction: Transaction, itemType: String, limit: Long) {
+    override suspend fun deleteOlderEvents(transaction: Transaction, itemType: String, limit: Long) {
         database.item_eventQueries
             .selectOlderCreatedIds(itemType, limit)
             .execute().use { cursor ->
@@ -109,42 +109,42 @@ internal class KottageSqliteItemEventRepository(
             }
     }
 
-    override fun deleteBefore(transaction: Transaction, createdAt: Long) {
+    override suspend fun deleteBefore(transaction: Transaction, createdAt: Long) {
         database.item_eventQueries
             .deleteBefore(createdAt)
     }
 
-    override fun deleteAll(transaction: Transaction, itemType: String) {
+    override suspend fun deleteAll(transaction: Transaction, itemType: String) {
         database.item_eventQueries
             .deleteAllByType(itemType)
     }
 
-    override fun deleteAllList(transaction: Transaction, listType: String) {
+    override suspend fun deleteAllList(transaction: Transaction, listType: String) {
         database.item_eventQueries
             .deleteAllByListType(item_list_type = listType)
     }
 
-    override fun getStatsCount(transaction: Transaction, itemType: String): Long {
+    override suspend fun getStatsCount(transaction: Transaction, itemType: String): Long {
         return database.item_statsQueries
             .select(itemType)
             .executeAsOneOrNull()?.event_count ?: 0
     }
 
-    override fun incrementStatsCount(transaction: Transaction, itemType: String, count: Long) {
+    override suspend fun incrementStatsCount(transaction: Transaction, itemType: String, count: Long) {
         database.item_statsQueries
             .insertIfNotExists(itemType)
         database.item_statsQueries
             .incrementEventCount(count, itemType)
     }
 
-    override fun decrementStatsCount(transaction: Transaction, itemType: String, count: Long) {
+    override suspend fun decrementStatsCount(transaction: Transaction, itemType: String, count: Long) {
         database.item_statsQueries
             .insertIfNotExists(itemType)
         database.item_statsQueries
             .decrementEventCount(count, itemType)
     }
 
-    override fun updateStatsCount(transaction: Transaction, itemType: String, count: Long) {
+    override suspend fun updateStatsCount(transaction: Transaction, itemType: String, count: Long) {
         database.item_statsQueries
             .insertIfNotExists(itemType)
         database.item_statsQueries

--- a/kottage/src/commonSqliteMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageSqliteItemListRepository.kt
+++ b/kottage/src/commonSqliteMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageSqliteItemListRepository.kt
@@ -3,18 +3,19 @@ package io.github.irgaly.kottage.internal.repository
 import com.squareup.sqldelight.db.use
 import io.github.irgaly.kottage.data.sqlite.Item_list_stats
 import io.github.irgaly.kottage.data.sqlite.KottageDatabase
+import io.github.irgaly.kottage.internal.database.Transaction
 import io.github.irgaly.kottage.internal.model.ItemListEntry
 import io.github.irgaly.kottage.internal.model.ItemListStats
 
 internal class KottageSqliteItemListRepository(
     private val database: KottageDatabase
 ) : KottageItemListRepository {
-    override fun upsert(entry: ItemListEntry) {
+    override fun upsert(transaction: Transaction, entry: ItemListEntry) {
         database.item_listQueries
             .replace(entry.toEntity())
     }
 
-    override fun updatePreviousId(id: String, previousId: String?) {
+    override fun updatePreviousId(transaction: Transaction, id: String, previousId: String?) {
         database.item_listQueries
             .updatePreviousId(
                 previous_id = previousId,
@@ -22,7 +23,7 @@ internal class KottageSqliteItemListRepository(
             )
     }
 
-    override fun updateNextId(id: String, nextId: String?) {
+    override fun updateNextId(transaction: Transaction, id: String, nextId: String?) {
         database.item_listQueries
             .updateNextId(
                 next_id = nextId,
@@ -30,7 +31,13 @@ internal class KottageSqliteItemListRepository(
             )
     }
 
-    override fun updateItemKey(id: String, itemType: String, itemKey: String?, expireAt: Long?) {
+    override fun updateItemKey(
+        transaction: Transaction,
+        id: String,
+        itemType: String,
+        itemKey: String?,
+        expireAt: Long?
+    ) {
         database.item_listQueries
             .updateItemKey(
                 item_key = itemKey,
@@ -40,7 +47,7 @@ internal class KottageSqliteItemListRepository(
             )
     }
 
-    override fun updateExpireAt(id: String, expireAt: Long?) {
+    override fun updateExpireAt(transaction: Transaction, id: String, expireAt: Long?) {
         database.item_listQueries
             .updateExpireAt(
                 expire_at = expireAt,
@@ -48,23 +55,23 @@ internal class KottageSqliteItemListRepository(
             )
     }
 
-    override fun removeItemKey(id: String) {
+    override fun removeItemKey(transaction: Transaction, id: String) {
         database.item_listQueries
             .removeItemKey(id = id)
     }
 
-    override fun removeUserData(id: String) {
+    override fun removeUserData(transaction: Transaction, id: String) {
         database.item_listQueries
             .removeUserData(id = id)
     }
 
-    override fun get(id: String): ItemListEntry? {
+    override fun get(transaction: Transaction, id: String): ItemListEntry? {
         return database.item_listQueries
             .select(id = id)
             .executeAsOneOrNull()?.toDomain()
     }
 
-    override fun getIds(itemType: String, itemKey: String): List<String> {
+    override fun getIds(transaction: Transaction, itemType: String, itemKey: String): List<String> {
         return database.item_listQueries
             .selectIdFromItem(
                 item_type = itemType,
@@ -73,6 +80,7 @@ internal class KottageSqliteItemListRepository(
     }
 
     override fun getInvalidatedItemIds(
+        transaction: Transaction,
         type: String,
         beforeExpireAt: Long?,
         limit: Long
@@ -93,19 +101,19 @@ internal class KottageSqliteItemListRepository(
         }
     }
 
-    override fun getCount(type: String): Long {
+    override fun getCount(transaction: Transaction, type: String): Long {
         return database.item_listQueries
             .countByType(type = type)
             .executeAsOne()
     }
 
-    override fun getInvalidatedItemCount(type: String): Long {
+    override fun getInvalidatedItemCount(transaction: Transaction, type: String): Long {
         return database.item_listQueries
             .countInvalidatedItem(type = type)
             .executeAsOne()
     }
 
-    override fun getAllTypes(receiver: (type: String) -> Unit) {
+    override fun getAllTypes(transaction: Transaction, receiver: (type: String) -> Unit) {
         database.item_list_statsQueries
             .selectAllItemListType()
             .execute().use { cursor ->
@@ -116,17 +124,18 @@ internal class KottageSqliteItemListRepository(
             }
     }
 
-    override fun delete(id: String) {
+    override fun delete(transaction: Transaction, id: String) {
         database.item_listQueries
             .delete(id = id)
     }
 
-    override fun deleteAll(type: String) {
+    override fun deleteAll(transaction: Transaction, type: String) {
         database.item_listQueries
             .deleteAllByType(type = type)
     }
 
     override fun createStats(
+        transaction: Transaction,
         type: String,
         count: Long,
         firstItemListEntryId: String,
@@ -143,19 +152,19 @@ internal class KottageSqliteItemListRepository(
             )
     }
 
-    override fun getStats(type: String): ItemListStats? {
+    override fun getStats(transaction: Transaction, type: String): ItemListStats? {
         return database.item_list_statsQueries
             .select(item_list_type = type)
             .executeAsOneOrNull()?.toDomain()
     }
 
-    override fun getStatsCount(type: String): Long {
+    override fun getStatsCount(transaction: Transaction, type: String): Long {
         return database.item_list_statsQueries
             .select(item_list_type = type)
             .executeAsOneOrNull()?.count ?: 0
     }
 
-    override fun incrementStatsCount(type: String, count: Long) {
+    override fun incrementStatsCount(transaction: Transaction, type: String, count: Long) {
         database.item_list_statsQueries
             .incrementCount(
                 count = count,
@@ -163,7 +172,7 @@ internal class KottageSqliteItemListRepository(
             )
     }
 
-    override fun decrementStatsCount(type: String, count: Long) {
+    override fun decrementStatsCount(transaction: Transaction, type: String, count: Long) {
         database.item_list_statsQueries
             .decrementCount(
                 count = count,
@@ -171,7 +180,7 @@ internal class KottageSqliteItemListRepository(
             )
     }
 
-    override fun updateStatsCount(type: String, count: Long) {
+    override fun updateStatsCount(transaction: Transaction, type: String, count: Long) {
         database.item_list_statsQueries
             .updateCount(
                 count = count,
@@ -179,7 +188,7 @@ internal class KottageSqliteItemListRepository(
             )
     }
 
-    override fun updateStatsFirstItem(type: String, id: String) {
+    override fun updateStatsFirstItem(transaction: Transaction, type: String, id: String) {
         database.item_list_statsQueries
             .updateFirstItemListId(
                 first_item_list_id = id,
@@ -187,7 +196,7 @@ internal class KottageSqliteItemListRepository(
             )
     }
 
-    override fun updateStatsLastItem(type: String, id: String) {
+    override fun updateStatsLastItem(transaction: Transaction, type: String, id: String) {
         database.item_list_statsQueries
             .updateLastItemListId(
                 last_item_list_id = id,
@@ -195,7 +204,7 @@ internal class KottageSqliteItemListRepository(
             )
     }
 
-    override fun deleteStats(type: String) {
+    override fun deleteStats(transaction: Transaction, type: String) {
         database.item_list_statsQueries
             .delete(item_list_type = type)
     }

--- a/kottage/src/commonSqliteMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageSqliteItemListRepository.kt
+++ b/kottage/src/commonSqliteMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageSqliteItemListRepository.kt
@@ -161,7 +161,7 @@ internal class KottageSqliteItemListRepository(
     override suspend fun getStatsCount(transaction: Transaction, type: String): Long {
         return database.item_list_statsQueries
             .select(item_list_type = type)
-            .executeAsOneOrNull()?.count ?: 0
+            .executeAsOneOrNull()?.count ?: 0L
     }
 
     override suspend fun incrementStatsCount(transaction: Transaction, type: String, count: Long) {

--- a/kottage/src/commonSqliteMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageSqliteItemListRepository.kt
+++ b/kottage/src/commonSqliteMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageSqliteItemListRepository.kt
@@ -10,12 +10,12 @@ import io.github.irgaly.kottage.internal.model.ItemListStats
 internal class KottageSqliteItemListRepository(
     private val database: KottageDatabase
 ) : KottageItemListRepository {
-    override fun upsert(transaction: Transaction, entry: ItemListEntry) {
+    override suspend fun upsert(transaction: Transaction, entry: ItemListEntry) {
         database.item_listQueries
             .replace(entry.toEntity())
     }
 
-    override fun updatePreviousId(transaction: Transaction, id: String, previousId: String?) {
+    override suspend fun updatePreviousId(transaction: Transaction, id: String, previousId: String?) {
         database.item_listQueries
             .updatePreviousId(
                 previous_id = previousId,
@@ -23,7 +23,7 @@ internal class KottageSqliteItemListRepository(
             )
     }
 
-    override fun updateNextId(transaction: Transaction, id: String, nextId: String?) {
+    override suspend fun updateNextId(transaction: Transaction, id: String, nextId: String?) {
         database.item_listQueries
             .updateNextId(
                 next_id = nextId,
@@ -31,7 +31,7 @@ internal class KottageSqliteItemListRepository(
             )
     }
 
-    override fun updateItemKey(
+    override suspend fun updateItemKey(
         transaction: Transaction,
         id: String,
         itemType: String,
@@ -47,7 +47,7 @@ internal class KottageSqliteItemListRepository(
             )
     }
 
-    override fun updateExpireAt(transaction: Transaction, id: String, expireAt: Long?) {
+    override suspend fun updateExpireAt(transaction: Transaction, id: String, expireAt: Long?) {
         database.item_listQueries
             .updateExpireAt(
                 expire_at = expireAt,
@@ -55,23 +55,23 @@ internal class KottageSqliteItemListRepository(
             )
     }
 
-    override fun removeItemKey(transaction: Transaction, id: String) {
+    override suspend fun removeItemKey(transaction: Transaction, id: String) {
         database.item_listQueries
             .removeItemKey(id = id)
     }
 
-    override fun removeUserData(transaction: Transaction, id: String) {
+    override suspend fun removeUserData(transaction: Transaction, id: String) {
         database.item_listQueries
             .removeUserData(id = id)
     }
 
-    override fun get(transaction: Transaction, id: String): ItemListEntry? {
+    override suspend fun get(transaction: Transaction, id: String): ItemListEntry? {
         return database.item_listQueries
             .select(id = id)
             .executeAsOneOrNull()?.toDomain()
     }
 
-    override fun getIds(transaction: Transaction, itemType: String, itemKey: String): List<String> {
+    override suspend fun getIds(transaction: Transaction, itemType: String, itemKey: String): List<String> {
         return database.item_listQueries
             .selectIdFromItem(
                 item_type = itemType,
@@ -79,7 +79,7 @@ internal class KottageSqliteItemListRepository(
             ).executeAsList()
     }
 
-    override fun getInvalidatedItemIds(
+    override suspend fun getInvalidatedItemIds(
         transaction: Transaction,
         type: String,
         beforeExpireAt: Long?,
@@ -101,19 +101,19 @@ internal class KottageSqliteItemListRepository(
         }
     }
 
-    override fun getCount(transaction: Transaction, type: String): Long {
+    override suspend fun getCount(transaction: Transaction, type: String): Long {
         return database.item_listQueries
             .countByType(type = type)
             .executeAsOne()
     }
 
-    override fun getInvalidatedItemCount(transaction: Transaction, type: String): Long {
+    override suspend fun getInvalidatedItemCount(transaction: Transaction, type: String): Long {
         return database.item_listQueries
             .countInvalidatedItem(type = type)
             .executeAsOne()
     }
 
-    override fun getAllTypes(transaction: Transaction, receiver: (type: String) -> Unit) {
+    override suspend fun getAllTypes(transaction: Transaction, receiver: suspend (type: String) -> Unit) {
         database.item_list_statsQueries
             .selectAllItemListType()
             .execute().use { cursor ->
@@ -124,17 +124,17 @@ internal class KottageSqliteItemListRepository(
             }
     }
 
-    override fun delete(transaction: Transaction, id: String) {
+    override suspend fun delete(transaction: Transaction, id: String) {
         database.item_listQueries
             .delete(id = id)
     }
 
-    override fun deleteAll(transaction: Transaction, type: String) {
+    override suspend fun deleteAll(transaction: Transaction, type: String) {
         database.item_listQueries
             .deleteAllByType(type = type)
     }
 
-    override fun createStats(
+    override suspend fun createStats(
         transaction: Transaction,
         type: String,
         count: Long,
@@ -152,19 +152,19 @@ internal class KottageSqliteItemListRepository(
             )
     }
 
-    override fun getStats(transaction: Transaction, type: String): ItemListStats? {
+    override suspend fun getStats(transaction: Transaction, type: String): ItemListStats? {
         return database.item_list_statsQueries
             .select(item_list_type = type)
             .executeAsOneOrNull()?.toDomain()
     }
 
-    override fun getStatsCount(transaction: Transaction, type: String): Long {
+    override suspend fun getStatsCount(transaction: Transaction, type: String): Long {
         return database.item_list_statsQueries
             .select(item_list_type = type)
             .executeAsOneOrNull()?.count ?: 0
     }
 
-    override fun incrementStatsCount(transaction: Transaction, type: String, count: Long) {
+    override suspend fun incrementStatsCount(transaction: Transaction, type: String, count: Long) {
         database.item_list_statsQueries
             .incrementCount(
                 count = count,
@@ -172,7 +172,7 @@ internal class KottageSqliteItemListRepository(
             )
     }
 
-    override fun decrementStatsCount(transaction: Transaction, type: String, count: Long) {
+    override suspend fun decrementStatsCount(transaction: Transaction, type: String, count: Long) {
         database.item_list_statsQueries
             .decrementCount(
                 count = count,
@@ -180,7 +180,7 @@ internal class KottageSqliteItemListRepository(
             )
     }
 
-    override fun updateStatsCount(transaction: Transaction, type: String, count: Long) {
+    override suspend fun updateStatsCount(transaction: Transaction, type: String, count: Long) {
         database.item_list_statsQueries
             .updateCount(
                 count = count,
@@ -188,7 +188,7 @@ internal class KottageSqliteItemListRepository(
             )
     }
 
-    override fun updateStatsFirstItem(transaction: Transaction, type: String, id: String) {
+    override suspend fun updateStatsFirstItem(transaction: Transaction, type: String, id: String) {
         database.item_list_statsQueries
             .updateFirstItemListId(
                 first_item_list_id = id,
@@ -196,7 +196,7 @@ internal class KottageSqliteItemListRepository(
             )
     }
 
-    override fun updateStatsLastItem(transaction: Transaction, type: String, id: String) {
+    override suspend fun updateStatsLastItem(transaction: Transaction, type: String, id: String) {
         database.item_list_statsQueries
             .updateLastItemListId(
                 last_item_list_id = id,
@@ -204,7 +204,7 @@ internal class KottageSqliteItemListRepository(
             )
     }
 
-    override fun deleteStats(transaction: Transaction, type: String) {
+    override suspend fun deleteStats(transaction: Transaction, type: String) {
         database.item_list_statsQueries
             .delete(item_list_type = type)
     }

--- a/kottage/src/commonSqliteMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageSqliteItemRepository.kt
+++ b/kottage/src/commonSqliteMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageSqliteItemRepository.kt
@@ -10,12 +10,12 @@ import io.github.irgaly.kottage.internal.model.ItemStats
 internal class KottageSqliteItemRepository(
     private val database: KottageDatabase
 ) : KottageItemRepository {
-    override fun upsert(transaction: Transaction, item: Item) {
+    override suspend fun upsert(transaction: Transaction, item: Item) {
         database.itemQueries
             .replace(item.toEntity())
     }
 
-    override fun updateLastRead(
+    override suspend fun updateLastRead(
         transaction: Transaction,
         key: String,
         itemType: String,
@@ -25,7 +25,7 @@ internal class KottageSqliteItemRepository(
             .updateLastRead(lastReadAt, Item.toEntityKey(key, itemType))
     }
 
-    override fun updateExpireAt(
+    override suspend fun updateExpireAt(
         transaction: Transaction,
         key: String,
         itemType: String,
@@ -35,28 +35,28 @@ internal class KottageSqliteItemRepository(
             .updateExpireAt(expireAt, Item.toEntityKey(key, itemType))
     }
 
-    override fun exists(transaction: Transaction, key: String, itemType: String): Boolean {
+    override suspend fun exists(transaction: Transaction, key: String, itemType: String): Boolean {
         return database.itemQueries
             .selectKey(Item.toEntityKey(key, itemType))
             .executeAsExists()
     }
 
-    override fun get(transaction: Transaction, key: String, itemType: String): Item? {
+    override suspend fun get(transaction: Transaction, key: String, itemType: String): Item? {
         return database.itemQueries
             .select(Item.toEntityKey(key, itemType))
             .executeAsOneOrNull()?.toDomain()
     }
 
-    override fun getCount(transaction: Transaction, itemType: String): Long {
+    override suspend fun getCount(transaction: Transaction, itemType: String): Long {
         return database.itemQueries
             .countByType(itemType)
             .executeAsOne()
     }
 
-    override fun getAllKeys(
+    override suspend fun getAllKeys(
         transaction: Transaction,
         itemType: String,
-        receiver: (key: String) -> Unit
+        receiver: suspend (key: String) -> Unit
     ) {
         database.itemQueries
             .selectAllKeys(itemType)
@@ -68,11 +68,11 @@ internal class KottageSqliteItemRepository(
             }
     }
 
-    override fun getExpiredKeys(
+    override suspend fun getExpiredKeys(
         transaction: Transaction,
         now: Long,
         itemType: String?,
-        receiver: (key: String, itemType: String) -> Unit
+        receiver: suspend (key: String, itemType: String) -> Unit
     ) {
         if (itemType != null) {
             database.itemQueries
@@ -96,11 +96,11 @@ internal class KottageSqliteItemRepository(
         }
     }
 
-    override fun getLeastRecentlyUsedKeys(
+    override suspend fun getLeastRecentlyUsedKeys(
         transaction: Transaction,
         itemType: String,
         limit: Long?,
-        receiver: (key: String) -> Boolean
+        receiver: suspend (key: String) -> Boolean
     ) {
         if (limit != null) {
             database.itemQueries
@@ -125,11 +125,11 @@ internal class KottageSqliteItemRepository(
         }
     }
 
-    override fun getOlderKeys(
+    override suspend fun getOlderKeys(
         transaction: Transaction,
         itemType: String,
         limit: Long?,
-        receiver: (key: String) -> Boolean
+        receiver: suspend (key: String) -> Boolean
     ) {
         if (limit != null) {
             database.itemQueries
@@ -154,57 +154,57 @@ internal class KottageSqliteItemRepository(
         }
     }
 
-    override fun getStats(transaction: Transaction, itemType: String): ItemStats? {
+    override suspend fun getStats(transaction: Transaction, itemType: String): ItemStats? {
         return database.item_statsQueries
             .select(item_type = itemType)
             .executeAsOneOrNull()?.toDomain()
     }
 
-    override fun getEmptyStats(transaction: Transaction, limit: Long): List<ItemStats> {
+    override suspend fun getEmptyStats(transaction: Transaction, limit: Long): List<ItemStats> {
         // クリーンアップ用途だけなので、selectEmptyStats Query はインデックスを使わない
         return database.item_statsQueries
             .selectEmptyStats(limit = limit)
             .executeAsList().map { it.toDomain() }
     }
 
-    override fun delete(transaction: Transaction, key: String, itemType: String) {
+    override suspend fun delete(transaction: Transaction, key: String, itemType: String) {
         database.itemQueries
             .delete(Item.toEntityKey(key, itemType))
     }
 
-    override fun deleteAll(transaction: Transaction, itemType: String) {
+    override suspend fun deleteAll(transaction: Transaction, itemType: String) {
         database.itemQueries
             .deleteAllByType(itemType)
     }
 
-    override fun getStatsCount(transaction: Transaction, itemType: String): Long {
+    override suspend fun getStatsCount(transaction: Transaction, itemType: String): Long {
         return database.item_statsQueries
             .select(itemType)
             .executeAsOneOrNull()?.count ?: 0
     }
 
-    override fun incrementStatsCount(transaction: Transaction, itemType: String, count: Long) {
+    override suspend fun incrementStatsCount(transaction: Transaction, itemType: String, count: Long) {
         database.item_statsQueries
             .insertIfNotExists(itemType)
         database.item_statsQueries
             .incrementCount(count, itemType)
     }
 
-    override fun decrementStatsCount(transaction: Transaction, itemType: String, count: Long) {
+    override suspend fun decrementStatsCount(transaction: Transaction, itemType: String, count: Long) {
         database.item_statsQueries
             .insertIfNotExists(itemType)
         database.item_statsQueries
             .decrementCount(count, itemType)
     }
 
-    override fun updateStatsCount(transaction: Transaction, itemType: String, count: Long) {
+    override suspend fun updateStatsCount(transaction: Transaction, itemType: String, count: Long) {
         database.item_statsQueries
             .insertIfNotExists(itemType)
         database.item_statsQueries
             .updateCount(count, itemType)
     }
 
-    override fun deleteStats(transaction: Transaction, itemType: String) {
+    override suspend fun deleteStats(transaction: Transaction, itemType: String) {
         database.item_statsQueries
             .delete(itemType)
     }

--- a/kottage/src/commonSqliteMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageSqliteStatsRepository.kt
+++ b/kottage/src/commonSqliteMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageSqliteStatsRepository.kt
@@ -1,13 +1,14 @@
 package io.github.irgaly.kottage.internal.repository
 
 import io.github.irgaly.kottage.data.sqlite.KottageDatabase
+import io.github.irgaly.kottage.internal.database.Transaction
 
 internal class KottageSqliteStatsRepository(
     private val database: KottageDatabase
 ) : KottageStatsRepository {
     private val key = "kottage"
 
-    override fun getLastEvictAt(): Long {
+    override fun getLastEvictAt(transaction: Transaction): Long {
         database.statsQueries
             .insertIfNotExists(key)
         return database.statsQueries
@@ -15,7 +16,7 @@ internal class KottageSqliteStatsRepository(
             .executeAsOne()
     }
 
-    override fun updateLastEvictAt(now: Long) {
+    override fun updateLastEvictAt(transaction: Transaction, now: Long) {
         database.statsQueries
             .insertIfNotExists(key)
         database.statsQueries

--- a/kottage/src/commonSqliteMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageSqliteStatsRepository.kt
+++ b/kottage/src/commonSqliteMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageSqliteStatsRepository.kt
@@ -8,7 +8,7 @@ internal class KottageSqliteStatsRepository(
 ) : KottageStatsRepository {
     private val key = "kottage"
 
-    override fun getLastEvictAt(transaction: Transaction): Long {
+    override suspend fun getLastEvictAt(transaction: Transaction): Long {
         database.statsQueries
             .insertIfNotExists(key)
         return database.statsQueries
@@ -16,7 +16,7 @@ internal class KottageSqliteStatsRepository(
             .executeAsOne()
     }
 
-    override fun updateLastEvictAt(transaction: Transaction, now: Long) {
+    override suspend fun updateLastEvictAt(transaction: Transaction, now: Long) {
         database.statsQueries
             .insertIfNotExists(key)
         database.statsQueries

--- a/kottage/src/commonTest/kotlin/io/github/irgaly/kottage/KottageCacheTest.kt
+++ b/kottage/src/commonTest/kotlin/io/github/irgaly/kottage/KottageCacheTest.kt
@@ -15,7 +15,7 @@ class KottageCacheTest : KottageSpec("kottage_cache", body = {
         context("Cache Expire") {
             val (kottage, calendar) = kottage()
             it("defaultExpireTime 経過で cache が消えること") {
-                val cache = kottage.cache("cache1") {
+                val cache = kottage.cache("defaultExpireTime") {
                     defaultExpireTime = 1.days.duration
                 }
                 cache.put("expire1", "value")
@@ -31,7 +31,7 @@ class KottageCacheTest : KottageSpec("kottage_cache", body = {
                 }
             }
             it("put expireTime 経過で cache が消えること") {
-                val cache = kottage.cache("cache2") {
+                val cache = kottage.cache("put_expireTime") {
                     defaultExpireTime = 2.days.duration
                 }
                 cache.put("expire1", "value", 1.days.duration)
@@ -53,7 +53,7 @@ class KottageCacheTest : KottageSpec("kottage_cache", body = {
             val (compactionKottage, calendar) = kottage("compaction") {
                 autoCompactionDuration = 1.days.duration
             }
-            val cache = compactionKottage.cache("cache1") {
+            val cache = compactionKottage.cache("cache") {
                 defaultExpireTime = 2.days.duration
             }
             it("autoCompactionDuration 経過で cache が自動削除される") {
@@ -75,7 +75,7 @@ class KottageCacheTest : KottageSpec("kottage_cache", body = {
         }
         context("FIFO Strategy") {
             val (kottage, calendar) = kottage()
-            val cache = kottage.cache("cache2") {
+            val cache = kottage.cache("fifo") {
                 strategy = KottageFifoStrategy(4, 2)
             }
             it("maxEntryCount を超えたら reduceCount だけ削除される") {
@@ -97,7 +97,7 @@ class KottageCacheTest : KottageSpec("kottage_cache", body = {
         }
         context("LRU Strategy") {
             val (kottage, calendar) = kottage()
-            val cache = kottage.cache("cache3") {
+            val cache = kottage.cache("lru") {
                 strategy = KottageLruStrategy(4, 2)
             }
             it("maxEntryCount を超えたら reduceCount だけ削除される") {

--- a/kottage/src/commonTest/kotlin/io/github/irgaly/kottage/KottageCacheTest.kt
+++ b/kottage/src/commonTest/kotlin/io/github/irgaly/kottage/KottageCacheTest.kt
@@ -76,10 +76,12 @@ class KottageCacheTest : KottageSpec("kottage_cache", body = {
         context("FIFO Strategy") {
             val (kottage, calendar) = kottage()
             val cache = kottage.cache("fifo") {
-                strategy = KottageFifoStrategy(4, 2)
+                strategy = KottageFifoStrategy(5, 3)
             }
             it("maxEntryCount を超えたら reduceCount だけ削除される") {
                 cache.put("1", "")
+                // created_at 重複のテスト
+                cache.put("1_2", "")
                 calendar.now += 1.milliseconds
                 cache.put("2", "")
                 calendar.now += 1.milliseconds
@@ -89,6 +91,7 @@ class KottageCacheTest : KottageSpec("kottage_cache", body = {
                 calendar.now += 1.milliseconds
                 cache.put("5", "")
                 cache.exists("1") shouldBe false
+                cache.exists("1_2") shouldBe false
                 cache.exists("2") shouldBe false
                 cache.exists("3") shouldBe true
                 cache.exists("4") shouldBe true

--- a/sample/js-browser/build.gradle.kts
+++ b/sample/js-browser/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    kotlin("multiplatform")
+}
+
+kotlin {
+    js(IR) {
+        binaries.executable()
+        browser()
+    }
+    sourceSets {
+        commonMain {
+            dependencies {
+                implementation(projects.kottage)
+            }
+        }
+        val jsMain by getting {
+            dependencies {
+            }
+        }
+    }
+}

--- a/sample/js-browser/src/commonMain/kotlin/io/github/irgaly/kottage/sample/Main.kt
+++ b/sample/js-browser/src/commonMain/kotlin/io/github/irgaly/kottage/sample/Main.kt
@@ -1,0 +1,29 @@
+package io.github.irgaly.kottage.sample
+
+import io.github.irgaly.kottage.Kottage
+import io.github.irgaly.kottage.KottageEnvironment
+import io.github.irgaly.kottage.platform.KottageCalendar
+import io.github.irgaly.kottage.platform.KottageContext
+import io.github.irgaly.kottage.put
+import kotlinx.browser.window
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
+import kotlin.js.Date
+
+fun main() {
+    window.onload = {
+        MainScope().launch {
+            val calendar = object: KottageCalendar {
+                override fun nowUnixTimeMillis(): Long {
+                    return Date.now().toLong()
+                }
+            }
+            val environment = KottageEnvironment(KottageContext(), calendar)
+            val kottage = Kottage("name", "directory", environment) {
+
+            }
+            val storage = kottage.storage("storage")
+            storage.put("key1", "value1")
+        }
+    }
+}

--- a/sample/js-browser/src/jsMain/resources/index.html
+++ b/sample/js-browser/src/jsMain/resources/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Kottage JS</title>
+</head>
+<body>
+<script src="js-browser.js"></script>
+</body>
+</html>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,8 +7,8 @@ pluginManagement {
         gradlePluginPortal()
     }
     plugins {
-        id("com.android.application") version "8.0.0-alpha05"
-        id("com.android.library") version "8.0.0-alpha05"
+        id("com.android.application") version "8.0.0-alpha06"
+        id("com.android.library") version "8.0.0-alpha06"
         id("io.kotest.multiplatform") version "5.5.1"
         kotlin("android") version "1.7.10"
         kotlin("multiplatform") version "1.7.10"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,7 +26,7 @@ rootProject.name = "kottage-project"
 include(
     ":kottage",
     ":kottage:data:sqlite",
-    //":kottage:data:indexeddb",
+    ":kottage:data:indexeddb",
     ":kottage:core",
     ":kottage:core:test",
     ":sample:android"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,6 +29,7 @@ include(
     ":kottage:data:indexeddb",
     ":kottage:core",
     ":kottage:core:test",
-    ":sample:android"
+    ":sample:android",
+    ":sample:js-browser"
 )
 includeBuild("build-logic")


### PR DESCRIPTION
indexddb をそのまま使って JS browser に対応する

TODO:

* [x] indexeddb: Long -> Double 変換 (32bit浮動小数範囲へ変換)
* [x] indexeddb: bound (Long -> Double)
* [x] indexeddb: cursor collect 内での suspend 禁止
    * [x] reproducer を作って https://github.com/JuulLabs/indexeddb にバグ報告する
    * [x] -> https://github.com/JuulLabs/indexeddb/issues/75
* ~ByteArray -> Blob 化~
    * ブラウザから indexeddb の中身を確認して、ByteArray がバイナリデータとして扱われているならそのままでOK

---

indexeddb での Blob, ByteArray = Int8Array 表現調査:

Blob と Int8Array は別物として保存されているが、Int8Array も Blob に比べて効率が悪くはなさそうなので Int8Array のままで OK

![image](https://user-images.githubusercontent.com/1311446/198886170-3e958593-e6a0-40f3-b067-7003129cb740.png)

また、ArrayBuffer でも Blob でも、一定サイズを超えると blob 形式のファイルとして扱われるらしい。
Kottage は小さなバイナリデータを扱うことの方が多いので ArrayBuffer で OK

https://iwatendo.hateblo.jp/entry/2018/02/15/215811
