### PR TITLE
Add Linux Test

### DIFF
--- a/.github/workflows/build_test_linux.yml
+++ b/.github/workflows/build_test_linux.yml
@@ -6,7 +6,16 @@ on: push
 jobs:
   build-test:
     runs-on: ubuntu-latest
+    container:
+      image: gcc:7.3
     steps:
+      - name: Setup Container
+        run: |
+          # glibc 2.27 以下を使うために gcc:7.3 イメージを利用
+          echo "deb [trusted=yes] http://deb.debian.org/debian stretch-backports main" >> /etc/apt/sources.list
+          apt update
+          # VACUUM INTO のために sqlite 3.27 以上にアップデート
+          apt-get -yt stretch-backports install libsqlite3-dev
       - uses: actions/checkout@v3
       - id: get-month
         run: echo "month=$(TZ=Asia/Tokyo date +%m)" >> $GITHUB_OUTPUT
@@ -47,13 +56,25 @@ jobs:
       - name: Linux Test
         run: |
           ./gradlew linuxX64Test
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: test-results
+          path: "**/build/test-results/*/*.xml"
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: test-reports
+          path: "**/build/reports/tests/*"
+  upload-test:
+    runs-on: ubuntu-latest
+    needs: [ build-test ]
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: test-results
       - uses: EnricoMi/publish-unit-test-result-action/composite@v2
         if: always()
         with:
           junit_files: "**/build/test-results/*/*.xml"
           comment_mode: off
-      - uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: test-results
-          path: "**/build/reports/tests/*"

--- a/.github/workflows/build_test_linux.yml
+++ b/.github/workflows/build_test_linux.yml
@@ -1,0 +1,59 @@
+# コミットごとに Unit Test 実行
+name: Build & Test (Linux)
+
+on: push
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - id: get-month
+        run: echo "month=$(TZ=Asia/Tokyo date +%m)" >> $GITHUB_OUTPUT
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+      - uses: actions/cache@v3
+        with:
+          path: ~/.gradle/wrapper
+          key: gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches/jars-*
+            ~/.gradle/caches/transforms-*
+            ~/.gradle/caches/modules-*
+          key: gradle-dependencies-${{ steps.get-month.outputs.month }}-${{ hashFiles('gradle/libs.versions.toml', '**/*.gradle.kts', 'build-logic/**/*.{kt,kts}') }}
+          restore-keys: gradle-dependencies-${{ steps.get-month.outputs.month }}-
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.konan
+            ~/.gradle/native
+          key: ${{ runner.os }}-kotlin-native-${{ steps.get-month.outputs.month }}-${{ hashFiles('gradle/libs.versions.toml', '**/*.gradle.kts') }}
+          restore-keys: ${{ runner.os }}-kotlin-native-${{ steps.get-month.outputs.month }}-
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches/build-cache-*
+            ~/.gradle/caches/[0-9]*.*
+            .gradle
+          key: ${{ runner.os }}-gradle-build-${{ github.workflow }}-${{ steps.get-month.outputs.month }}-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-gradle-build-${{ github.workflow }}-${{ steps.get-month.outputs.month }}-
+      - name: Linux Test Build
+        run: |
+          ./gradlew linkDebugTestLinuxX64
+      - name: Linux Test
+        run: |
+          ./gradlew linuxX64Test
+      - uses: EnricoMi/publish-unit-test-result-action/composite@v2
+        if: always()
+        with:
+          junit_files: "**/build/test-results/*/*.xml"
+          comment_mode: off
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: test-results
+          path: "**/build/reports/tests/*"

--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ work correctly on these platforms.
 | Kotlin/Native watchOS | watchosArm64<br>watchosX64(simulator)<br>watchosSimulatorArm64 | :white_check_mark: Supported, :+1: Tested as Darwin on macOS                                     |
 | Kotlin/Native tvOS    | tvosArm64<br>tvosX64(simulator)<br>tvosSimulatorArm64          | :white_check_mark: Supported, :+1: Tested as Darwin on macOS                                     |
 | Kotlin/Native macOS   | macosArm64<br>macosX64                                         | :white_check_mark: Supported, :white_check_mark: Tested                                          |
-| Kotlin/Native Linux   | linuxX64                                                       | :white_check_mark: Supported, :tired_face: currently no automated unit tests.                    |
+| Kotlin/Native Linux   | linuxX64                                                       | :white_check_mark: Supported, :white_check_mark: Tested                                          |
 | Kotlin/Native Windows | mingwX64                                                       | :white_check_mark: Supported, :tired_face: currently no automated unit tests.                    |
 
 There is also [Kottage for SwiftPM](https://github.com/irgaly/kottage-package) that is **just for

--- a/kottage/build.gradle.kts
+++ b/kottage/build.gradle.kts
@@ -99,12 +99,17 @@ kotlin {
         }
     }
     targets.withType<KotlinNativeTarget> {
-        if (listOf("ios", "macos", "tvos", "watchos").any { it in name }) {
+        if (listOf("ios", "macos", "tvos", "watchos", "linux").any { it in name }) {
             binaries.all {
                 // fix test build: "Undefined symbols for architecture arm64:"
                 // https://github.com/cashapp/sqldelight/issues/3296
                 // https://github.com/cashapp/sqldelight/blob/ee8eb4390dedaaf735937896aef9f0ed56f3281e/drivers/native-driver/build.gradle
                 linkerOpts.add("-lsqlite3")
+                if (System.getenv().containsKey("GITHUB_ACTIONS")
+                    && OperatingSystem.current().isLinux
+                ) {
+                    linkerOpts.add("-L/usr/lib/x86_64-linux-gnu")
+                }
             }
         }
     }

--- a/kottage/core/src/android/main/kotlin/io/github/irgaly/kottage/platform/Context.kt
+++ b/kottage/core/src/android/main/kotlin/io/github/irgaly/kottage/platform/Context.kt
@@ -5,7 +5,7 @@ actual class Context {
         private set
 
     actual constructor() {
-        throw NotImplementedError("use context constructor on Android platform")
+        throw UnsupportedOperationException("use context constructor on Android platform")
     }
 
     constructor(context: android.content.Context) {

--- a/kottage/core/test/src/linuxMain/kotlin/io/github/irgaly/test/platform/Files.kt
+++ b/kottage/core/test/src/linuxMain/kotlin/io/github/irgaly/test/platform/Files.kt
@@ -1,14 +1,37 @@
 package io.github.irgaly.test.platform
 
+import kotlinx.cinterop.cstr
+import kotlinx.cinterop.staticCFunction
+import kotlinx.cinterop.toKString
+import platform.posix.FTW_DEPTH
+import platform.posix.FTW_PHYS
+import platform.posix.getenv
+import platform.posix.mkdtemp
+import platform.posix.nftw
+import platform.posix.remove
+
 actual class Files {
     actual companion object {
         actual fun createTemporaryDirectory(): String {
-            throw NotImplementedError()
+            val tempDirectory =
+                sequenceOf("TMPDIR", "TMP", "TEMP", "TEMPDIR").firstNotNullOfOrNull {
+                    getenv(it)?.toKString()
+                } ?: "/tmp"
+            val directory = mkdtemp("$tempDirectory/tmpdir.XXXXXX".cstr)?.toKString()
+            return checkNotNull(directory)
         }
 
 
         actual fun deleteRecursively(directoryPath: String): Boolean {
-            throw NotImplementedError()
+            val ret = nftw(
+                directoryPath,
+                staticCFunction { pathName, _, _, _ ->
+                    remove(pathName!!.toKString())
+                },
+                64,
+                FTW_DEPTH or FTW_PHYS
+            )
+            return (ret != -1)
         }
     }
 }

--- a/kottage/data/sqlite/build.gradle.kts
+++ b/kottage/data/sqlite/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.gradle.internal.os.OperatingSystem
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+
 plugins {
     id(libs.plugins.buildlogic.multiplatform.library.get().pluginId)
     id(libs.plugins.buildlogic.android.library.get().pluginId)
@@ -50,6 +53,17 @@ kotlin {
             dependencies {
                 implementation(npm("better-sqlite3", "7.6.2"))
                 //implementation(npm("@types/better-sqlite3", "7.6.2", generateExternals = true))
+            }
+        }
+    }
+    if (System.getenv().containsKey("GITHUB_ACTIONS")
+        && OperatingSystem.current().isLinux
+    ) {
+        targets.withType<KotlinNativeTarget> {
+            if ("linux" in name) {
+                binaries.all {
+                    linkerOpts.add("-L/usr/lib/x86_64-linux-gnu")
+                }
             }
         }
     }


### PR DESCRIPTION
Linux Test を追加しようとしたが、GitHub Actions Ubuntu-latest 環境でうまくビルドが通らない。

問題は以下の通り:

* konan は Linux 環境では glibc 2.19 + ld.gold をダウンロードしてきて使おうとする 
   * https://github.com/JetBrains/kotlin/blob/92ec8e6a3e52eb3eba467ee10589c1b06101798f/kotlin-native/tools/toolchain_builder/toolchains/x86_64-unknown-linux-gnu/gcc-8.3.0-glibc-2.19-kernel-4.9.config
   * glibc 2.27 以下では sqlite3 をビルドできない
       * `error: undefined symbol: fcntl64`
       * これと同じ問題 https://github.com/ziglang/zig/issues/9485
* GitHub Actions Ubuntu では /lib/x86_64-linux-gnu に libsqlite3.so が設置されているが ld.gold が /lib/x86_64-linux-gnu を三唱できておらずエラー
    * `ld.gold: error: cannot find -lsqlite3`
* `~/.konan/kotlin-native-prebuilt-linux-x86_64-1.7.10/konan/konan.properties` を書き換えて ld を差し替えられる
    * https://github.com/JetBrains/kotlin/blob/92ec8e6a3e52eb3eba467ee10589c1b06101798f/kotlin-native/konan/konan.properties#L545
    * `linker.linux_x64=/usr/bin/ld`
* ld -L オプションを指定する

```kotlin
// kottage/data/sqlite/build.gradle.kts
    targets.withType<org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget> {
            binaries.all {
                linkerOpts.add("-lsqlite3")
                linkerOpts.add("-L/lib/x86_64-linux-gnu")
            }
    }
```

まだエラーが出る

```
/usr/bin/ld: /lib/x86_64-linux-gnu/libsqlite3.so: undefined reference to `fcntl64@GLIBC_2.28'
/usr/bin/ld: /lib/x86_64-linux-gnu/libsqlite3.so: undefined reference to `log@GLIBC_2.29'
```