### PR TITLE
fix: KottageList.getPageFrom hangups with invalid positionId

### DIFF
--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageListImpl.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageListImpl.kt
@@ -79,15 +79,16 @@ internal class KottageListImpl(
                     (pageSize?.let { items.size < it } != false)
                     && (nextPositionId != null)
                 ) {
-                    listOperator.getAvailableListEntry(
+                    val entry = listOperator.getAvailableListEntry(
                         this,
                         positionId = nextPositionId,
                         direction = direction
-                    )?.let { entry ->
-                        nextPositionId = when (direction) {
-                            KottageListDirection.Forward -> entry.nextId
-                            KottageListDirection.Backward -> entry.previousId
-                        }
+                    )
+                    nextPositionId = when (direction) {
+                        KottageListDirection.Forward -> entry?.nextId
+                        KottageListDirection.Backward -> entry?.previousId
+                    }
+                    if (entry != null) {
                         val itemKey = checkNotNull(entry.itemKey)
                         val item = checkNotNull(
                             storageOperator.getOrNull(this, key = itemKey, now = null)

--- a/kottage/src/commonTest/kotlin/io/github/irgaly/kottage/KottageListTest.kt
+++ b/kottage/src/commonTest/kotlin/io/github/irgaly/kottage/KottageListTest.kt
@@ -49,6 +49,12 @@ class KottageListTest : KottageSpec("kottage_list", body = {
                     println(list.getDebugListRawData())
                 }
             }
+            it("missing") {
+                val cache = kottage().first.cache("missing")
+                val list = cache.list("list_missing")
+                list.get("missing_key") shouldBe null
+                list.getPageFrom("missing_key", 10).isEmpty shouldBe true
+            }
             it("update") {
                 val cache = kottage().first.cache("update")
                 val list = cache.list("list_update")


### PR DESCRIPTION
KottageList.getPageFrom に、存在しない positionId を渡すと処理が終了しない。

空の Page を返すのが正しい。