### PR TITLE
Support Kottage.close()

### DIFF
--- a/kottage/data/sqlite/src/commonMain/kotlin/io/github/irgaly/kottage/data/sqlite/DriverFactory.kt
+++ b/kottage/data/sqlite/src/commonMain/kotlin/io/github/irgaly/kottage/data/sqlite/DriverFactory.kt
@@ -13,6 +13,7 @@ expect class DriverFactory(
      *   * JVM: {directory}/{fileName}.db
      *   * Android: {directory}/{fileName}.db
      *   * Native (iOS, macOS, Linux, Windows): {directory}/{fileName}.db
+     *   * NodeJS: {directory}/{fileName}.db
      *
      * @param fileName 拡張子を除いた sqlite ファイル名。"{fileName}.db" として保存されます
      * @param directoryPath sqlite を保存するディレクトリ。該当ディレクトリは存在している必要がある。

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/database/IndexeddbDatabaseConnection.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/database/IndexeddbDatabaseConnection.kt
@@ -4,22 +4,21 @@ import io.github.irgaly.kottage.data.indexeddb.KottageIndexeddbDatabase
 import io.github.irgaly.kottage.data.indexeddb.schema.allStoreSchemaNames
 import io.github.irgaly.kottage.platform.Files
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
-import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 internal class IndexeddbDatabaseConnection(
     private val databaseName: String,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.Default
-) : DatabaseConnection {
+    scope: CoroutineScope,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.Default,
+) : DatabaseConnection, CoroutineScope by scope {
     private val mutex = Mutex()
 
-    @OptIn(DelicateCoroutinesApi::class)
-    val database = GlobalScope.async(dispatcher, CoroutineStart.LAZY) {
+    val database = async(dispatcher, CoroutineStart.LAZY) {
         KottageIndexeddbDatabase.open(databaseName)
     }
 

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/database/IndexeddbDatabaseConnectionFactory.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/database/IndexeddbDatabaseConnectionFactory.kt
@@ -7,16 +7,19 @@ import io.github.irgaly.kottage.data.indexeddb.schema.entity.Item_event
 import io.github.irgaly.kottage.data.indexeddb.schema.entity.Item_stats
 import io.github.irgaly.kottage.data.indexeddb.schema.entity.Stats
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 
 internal class IndexeddbDatabaseConnectionFactory: DatabaseConnectionFactory {
     override fun createDatabaseConnection(
         fileName: String,
         directoryPath: String,
         environment: KottageEnvironment,
+        scope: CoroutineScope,
         dispatcher: CoroutineDispatcher
     ): IndexeddbDatabaseConnection {
         return IndexeddbDatabaseConnection(
             databaseName = "$directoryPath/$fileName",
+            scope = scope,
             dispatcher = dispatcher
         )
     }
@@ -26,6 +29,7 @@ internal class IndexeddbDatabaseConnectionFactory: DatabaseConnectionFactory {
         directoryPath: String,
         environment: KottageEnvironment,
         version: Int,
+        scope: CoroutineScope,
         dispatcher: CoroutineDispatcher
     ) {
         if (3 <= version) {
@@ -33,6 +37,7 @@ internal class IndexeddbDatabaseConnectionFactory: DatabaseConnectionFactory {
         }
         IndexeddbDatabaseConnection(
             databaseName = "$directoryPath/$fileName",
+            scope = scope,
             dispatcher = dispatcher
         ).transaction {
             with((this as IndexeddbTransaction).transaction) {

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/database/IndexeddbDatabaseConnectionFactory.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/database/IndexeddbDatabaseConnectionFactory.kt
@@ -33,7 +33,7 @@ internal class IndexeddbDatabaseConnectionFactory: DatabaseConnectionFactory {
         dispatcher: CoroutineDispatcher
     ) {
         if (3 <= version) {
-            throw error("version 3 以降の indexeddb 初期化処理の実装が必要")
+            error("version 3 以降の indexeddb 初期化処理の実装が必要")
         }
         IndexeddbDatabaseConnection(
             databaseName = "$directoryPath/$fileName",

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/Kottage.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/Kottage.kt
@@ -84,6 +84,14 @@ class Kottage(
     val simpleEventFlow: Flow<KottageEvent> =
         databaseManager.eventFlow.map { KottageEvent.from(it) }
 
+    /**
+     * Database Connection is closed or not.
+     *
+     * If Kottage is closed, all database operation of this kottage instance will be fail.
+     * A closed Kottage instance cannot be reused.
+     */
+    val closed: Boolean get() = databaseManager.databaseConnectionClosed
+
     init {
         require(!name.contains(Files.separator)) { "name contains separator: $name" }
     }
@@ -171,6 +179,15 @@ class Kottage(
 
     suspend fun export(file: String, directoryPath: String) {
         databaseManager.backupTo(file, directoryPath)
+    }
+
+    /**
+     * Close Database connection
+     *
+     * If this Kottage instance is already closed, this method do nothing.
+     */
+    suspend fun close() {
+        databaseManager.closeDatabaseConnection()
     }
 
     data class DatabaseFiles(

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/Kottage.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/Kottage.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
+import kotlin.coroutines.coroutineContext
 import kotlin.time.Duration.Companion.days
 
 /**
@@ -65,6 +66,7 @@ class Kottage(
                 directoryPath = directoryPath,
                 environment = environment,
                 dispatcher = dispatcher,
+                scope = CoroutineScope(coroutineContext),
                 version = version
             )
         }
@@ -78,7 +80,14 @@ class Kottage(
     }.build()
 
     private val databaseManager: KottageDatabaseManager =
-        KottageDatabaseManager(name, directoryPath, options, environment, scope, dispatcher)
+        KottageDatabaseManager(
+            name,
+            directoryPath,
+            options,
+            environment,
+            scope,
+            dispatcher
+        )
 
     private val completionHandler: DisposableHandle
 
@@ -143,6 +152,7 @@ class Kottage(
             databaseManager,
             environment.calendar ?: KottageSystemCalendar(),
             { databaseManager.compact() },
+            scope,
             dispatcher
         )
     }
@@ -172,6 +182,7 @@ class Kottage(
             databaseManager,
             environment.calendar ?: KottageSystemCalendar(),
             { databaseManager.compact() },
+            scope,
             dispatcher
         )
     }

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/KottageEnvironment.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/KottageEnvironment.kt
@@ -2,11 +2,13 @@ package io.github.irgaly.kottage
 
 import io.github.irgaly.kottage.platform.KottageCalendar
 import io.github.irgaly.kottage.platform.KottageContext
+import io.github.irgaly.kottage.platform.KottageLogger
 
 /**
  * Runtime Environment
  */
 data class KottageEnvironment(
     val context: KottageContext,
-    val calendar: KottageCalendar? = null
+    val calendar: KottageCalendar? = null,
+    val logger: KottageLogger? = null
 )

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/KottageEventFlow.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/KottageEventFlow.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.FlowCollector
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -21,6 +21,7 @@ import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
+import kotlin.coroutines.coroutineContext
 
 /**
  * Resumable Event Flow
@@ -69,7 +70,8 @@ class KottageEventFlow internal constructor(
                         }
                     }
                 }
-                CoroutineScope(currentCoroutineContext()).launch(start = CoroutineStart.UNDISPATCHED) {
+                checkNotNull(coroutineContext[Job]) { "KottageEventFlow: subscriber CoroutineScope should have Job" }
+                CoroutineScope(coroutineContext).launch(start = CoroutineStart.UNDISPATCHED) {
                     // collect を開始した状態で eventFlow.withLock を抜ける
                     eventFlow.flow.let { flow ->
                         if (itemType != null) {

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageDatabaseManager.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageDatabaseManager.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
 
@@ -25,8 +24,8 @@ internal class KottageDatabaseManager(
     directoryPath: String,
     private val options: KottageOptions,
     private val environment: KottageEnvironment,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.Default,
-    private val scope: CoroutineScope = CoroutineScope(dispatcher + SupervisorJob())
+    scope: CoroutineScope,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.Default
 ) {
     private val databaseConnection by lazy {
         PlatformFactory().createDatabaseConnectionFactory()

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageDatabaseManager.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageDatabaseManager.kt
@@ -13,9 +13,7 @@ import io.github.irgaly.kottage.platform.KottageSystemCalendar
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
-import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
 
@@ -25,11 +23,11 @@ internal class KottageDatabaseManager(
     private val options: KottageOptions,
     private val environment: KottageEnvironment,
     scope: CoroutineScope,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.Default
-) {
+    private val dispatcher: CoroutineDispatcher = Dispatchers.Default,
+) : CoroutineScope by scope {
     private val databaseConnection by lazy {
         PlatformFactory().createDatabaseConnectionFactory()
-            .createDatabaseConnection(fileName, directoryPath, environment, dispatcher)
+            .createDatabaseConnection(fileName, directoryPath, environment, scope, dispatcher)
     }
 
     private val calendar = (environment.calendar ?: KottageSystemCalendar())
@@ -41,28 +39,23 @@ internal class KottageDatabaseManager(
 
     val databaseConnectionClosed: Boolean get() = databaseConnection.closed
 
-    @OptIn(DelicateCoroutinesApi::class)
-    val itemRepository = GlobalScope.async(dispatcher, CoroutineStart.LAZY) {
+    val itemRepository = async(dispatcher, CoroutineStart.LAZY) {
         repositoryFactory.createItemRepository()
     }
 
-    @OptIn(DelicateCoroutinesApi::class)
-    val itemListRepository = GlobalScope.async(dispatcher, CoroutineStart.LAZY) {
+    val itemListRepository = async(dispatcher, CoroutineStart.LAZY) {
         repositoryFactory.createItemListRepository()
     }
 
-    @OptIn(DelicateCoroutinesApi::class)
-    val itemEventRepository = GlobalScope.async(dispatcher, CoroutineStart.LAZY) {
+    val itemEventRepository = async(dispatcher, CoroutineStart.LAZY) {
         repositoryFactory.createItemEventRepository()
     }
 
-    @OptIn(DelicateCoroutinesApi::class)
-    val statsRepository = GlobalScope.async(dispatcher, CoroutineStart.LAZY) {
+    val statsRepository = async(dispatcher, CoroutineStart.LAZY) {
         repositoryFactory.createStatsRepository()
     }
 
-    @OptIn(DelicateCoroutinesApi::class)
-    val operator = GlobalScope.async(dispatcher, CoroutineStart.LAZY) {
+    val operator = async(dispatcher, CoroutineStart.LAZY) {
         KottageOperator(
             options,
             itemRepository.await(),

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageDatabaseManager.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageDatabaseManager.kt
@@ -40,6 +40,8 @@ internal class KottageDatabaseManager(
         PlatformFactory().createKottageRepositoryFactory(databaseConnection)
     }
 
+    val databaseConnectionClosed: Boolean get() = databaseConnection.closed
+
     @OptIn(DelicateCoroutinesApi::class)
     val itemRepository = GlobalScope.async(dispatcher, CoroutineStart.LAZY) {
         repositoryFactory.createItemRepository()
@@ -188,5 +190,9 @@ internal class KottageDatabaseManager(
             operator,
             dispatcher
         )
+    }
+
+    suspend fun closeDatabaseConnection() {
+        databaseConnection.close()
     }
 }

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageListImpl.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageListImpl.kt
@@ -18,10 +18,9 @@ import io.github.irgaly.kottage.platform.KottageCalendar
 import io.github.irgaly.kottage.strategy.KottageStrategy
 import io.github.irgaly.kottage.strategy.KottageTransaction
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
-import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.withContext
 import kotlin.reflect.KType
@@ -35,20 +34,19 @@ internal class KottageListImpl(
     private val databaseManager: KottageDatabaseManager,
     private val calendar: KottageCalendar,
     private val onCompactionRequired: suspend () -> Unit,
+    scope: CoroutineScope,
     private val dispatcher: CoroutineDispatcher = Dispatchers.Default
-): KottageList {
+) : KottageList, CoroutineScope by scope {
     private val itemType: String = storage.name
     private val listType: String = name
     private val strategy: KottageStrategy = storage.options.strategy
     private suspend fun operator() = databaseManager.operator.await()
 
-    @OptIn(DelicateCoroutinesApi::class)
-    private val storageOperator = GlobalScope.async(dispatcher, CoroutineStart.LAZY) {
+    private val storageOperator = async(dispatcher, CoroutineStart.LAZY) {
         databaseManager.getStorageOperator(storage)
     }
 
-    @OptIn(DelicateCoroutinesApi::class)
-    private val listOperator = GlobalScope.async(dispatcher, CoroutineStart.LAZY) {
+    private val listOperator = async(dispatcher, CoroutineStart.LAZY) {
         databaseManager.getListOperator(this@KottageListImpl, storage)
     }
 

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/database/DatabaseConnection.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/database/DatabaseConnection.kt
@@ -2,6 +2,11 @@ package io.github.irgaly.kottage.internal.database
 
 internal interface DatabaseConnection {
     /**
+     * Database connection is already closed
+     */
+    val closed: Boolean
+
+    /**
      * Exclusive Transaction
      */
     suspend fun <R> transactionWithResult(bodyWithReturn: suspend Transaction.() -> R): R
@@ -25,5 +30,6 @@ internal interface DatabaseConnection {
     suspend fun compact()
     suspend fun backupTo(file: String, directoryPath: String)
     suspend fun getDatabaseStatus(): String
+    suspend fun close()
 }
 

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/database/DatabaseConnectionFactory.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/database/DatabaseConnectionFactory.kt
@@ -2,6 +2,7 @@ package io.github.irgaly.kottage.internal.database
 
 import io.github.irgaly.kottage.KottageEnvironment
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 
 internal interface DatabaseConnectionFactory {
@@ -13,6 +14,7 @@ internal interface DatabaseConnectionFactory {
         fileName: String,
         directoryPath: String,
         environment: KottageEnvironment,
+        scope: CoroutineScope,
         dispatcher: CoroutineDispatcher = Dispatchers.Default
     ): DatabaseConnection
 
@@ -21,6 +23,7 @@ internal interface DatabaseConnectionFactory {
         directoryPath: String,
         environment: KottageEnvironment,
         version: Int,
+        scope: CoroutineScope,
         dispatcher: CoroutineDispatcher = Dispatchers.Default
     )
 }

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/platform/KottageLogger.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/platform/KottageLogger.kt
@@ -1,0 +1,10 @@
+package io.github.irgaly.kottage.platform
+
+interface KottageLogger {
+    suspend fun debug(message: String) {
+        // empty default method
+    }
+    suspend fun error(message: String) {
+        // empty default method
+    }
+}

--- a/kottage/src/commonSqliteMain/kotlin/io/github/irgaly/kottage/internal/database/SqliteDatabaseConnection.kt
+++ b/kottage/src/commonSqliteMain/kotlin/io/github/irgaly/kottage/internal/database/SqliteDatabaseConnection.kt
@@ -11,13 +11,17 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
-internal data class SqliteDatabaseConnection(
+internal class SqliteDatabaseConnection(
     private val sqlDriverProvider: suspend () -> SqlDriver,
     private val databaseProvider: suspend (sqlDriver: SqlDriver) -> KottageDatabase,
     private val dispatcher: CoroutineDispatcher = Dispatchers.Default
-): DatabaseConnection {
+) : DatabaseConnection {
+    private val mutex = Mutex()
+
     @OptIn(DelicateCoroutinesApi::class)
     private val sqlDriver = GlobalScope.async(dispatcher, CoroutineStart.LAZY) {
         sqlDriverProvider()
@@ -28,198 +32,244 @@ internal data class SqliteDatabaseConnection(
         databaseProvider(sqlDriver.await())
     }
 
+    override var closed: Boolean = false
+        private set
+
     private suspend fun <R> withDatabase(body: (sqlDriver: SqlDriver, database: KottageDatabase) -> R): R {
         return body(sqlDriver.await(), database.await())
     }
 
     override suspend fun <R> transactionWithResult(bodyWithReturn: suspend Transaction.() -> R): R =
         withContext(dispatcher) {
-            withDatabase { sqlDriver, database ->
-                database.transactionWithResult {
-                    // here: SQLDelight Transaction = DEFERRED (default)
-                    // restart transaction with EXCLUSIVE
-                    sqlDriver.execute(null, "END", 0)
-                    sqlDriver.execute(null, "BEGIN EXCLUSIVE", 0)
-                    var result: R? = null
-                    var finished = false
-                    launch(start = CoroutineStart.UNDISPATCHED) {
-                        // SQLite Transaction はスレッド切り替えなしで実行する
-                        result = bodyWithReturn(SqliteTransaction())
-                        finished = true
+            mutex.withLock {
+                if (closed) {
+                    error("Database connection is closed")
+                }
+                withDatabase { sqlDriver, database ->
+                    database.transactionWithResult {
+                        // here: SQLDelight Transaction = DEFERRED (default)
+                        // restart transaction with EXCLUSIVE
+                        sqlDriver.execute(null, "END", 0)
+                        sqlDriver.execute(null, "BEGIN EXCLUSIVE", 0)
+                        var result: R? = null
+                        var finished = false
+                        launch(start = CoroutineStart.UNDISPATCHED) {
+                            // SQLite Transaction はスレッド切り替えなしで実行する
+                            result = bodyWithReturn(SqliteTransaction())
+                            finished = true
+                        }
+                        if (!finished) {
+                            // スレッド切り替えなしで実行されたことを保証する
+                            error("database transaction invalid thread error")
+                        }
+                        @Suppress("UNCHECKED_CAST")
+                        result as R
                     }
-                    if (!finished) {
-                        // スレッド切り替えなしで実行されたことを保証する
-                        error("database transaction invalid thread error")
-                    }
-                    @Suppress("UNCHECKED_CAST")
-                    result as R
                 }
             }
         }
 
     override suspend fun transaction(body: suspend Transaction.() -> Unit) =
         withContext(dispatcher) {
-            withDatabase { sqlDriver, database ->
-                database.transaction {
-                    // here: SQLDelight Transaction = DEFERRED (default)
-                    // restart transaction with EXCLUSIVE
-                    sqlDriver.execute(null, "END", 0)
-                    sqlDriver.execute(null, "BEGIN EXCLUSIVE", 0)
-                    var finished = false
-                    launch(start = CoroutineStart.UNDISPATCHED) {
-                        // SQLite Transaction はスレッド切り替えなしで実行する
-                        body(SqliteTransaction())
-                    finished = true
+            mutex.withLock {
+                if (closed) {
+                    error("Database connection is closed")
                 }
-                if (!finished) {
-                    // スレッド切り替えなしで実行されたことを保証する
-                    error("database transaction invalid thread error")
+                withDatabase { sqlDriver, database ->
+                    database.transaction {
+                        // here: SQLDelight Transaction = DEFERRED (default)
+                        // restart transaction with EXCLUSIVE
+                        sqlDriver.execute(null, "END", 0)
+                        sqlDriver.execute(null, "BEGIN EXCLUSIVE", 0)
+                        var finished = false
+                        launch(start = CoroutineStart.UNDISPATCHED) {
+                            // SQLite Transaction はスレッド切り替えなしで実行する
+                            body(SqliteTransaction())
+                            finished = true
+                        }
+                        if (!finished) {
+                            // スレッド切り替えなしで実行されたことを保証する
+                            error("database transaction invalid thread error")
+                        }
+                    }
                 }
             }
         }
-    }
 
     override suspend fun deleteAll() = withContext(dispatcher) {
-        withDatabase { _, database ->
-            database.transaction {
-                database.itemQueries.deleteAll()
-                database.item_statsQueries.deleteAll()
-                database.item_listQueries.deleteAll()
-                database.item_list_statsQueries.deleteAll()
-                database.item_eventQueries.deleteAll()
-                database.statsQueries.deleteAll()
+        mutex.withLock {
+            if (closed) {
+                error("Database connection is closed")
+            }
+            withDatabase { _, database ->
+                database.transaction {
+                    database.itemQueries.deleteAll()
+                    database.item_statsQueries.deleteAll()
+                    database.item_listQueries.deleteAll()
+                    database.item_list_statsQueries.deleteAll()
+                    database.item_eventQueries.deleteAll()
+                    database.statsQueries.deleteAll()
+                }
             }
         }
     }
 
     override suspend fun compact() = withContext(dispatcher) {
-        withDatabase { sqlDriver, _ ->
-            // reduce WAL file size to zero / https://www.sqlite.org/pragma.html#pragma_wal_checkpoint
-            sqlDriver.executeQuery(null, "PRAGMA wal_checkpoint(TRUNCATE)", 0).close()
-            // reduce database file size and optimize b-tree / https://www.sqlite.org/matrix/lang_vacuum.html
-            sqlDriver.execute(null, "VACUUM", 0)
+        mutex.withLock {
+            if (closed) {
+                error("Database connection is closed")
+            }
+            withDatabase { sqlDriver, _ ->
+                // reduce WAL file size to zero / https://www.sqlite.org/pragma.html#pragma_wal_checkpoint
+                sqlDriver.executeQuery(null, "PRAGMA wal_checkpoint(TRUNCATE)", 0).close()
+                // reduce database file size and optimize b-tree / https://www.sqlite.org/matrix/lang_vacuum.html
+                sqlDriver.execute(null, "VACUUM", 0)
+            }
         }
     }
 
     override suspend fun backupTo(file: String, directoryPath: String) = withContext(dispatcher) {
-        withDatabase { sqlDriver, _ ->
-            require(!file.contains(Files.separator)) { "file contains separator: $file" }
-            if (!Files.exists(directoryPath)) {
-                Files.mkdirs(directoryPath)
+        mutex.withLock {
+            if (closed) {
+                error("Database connection is closed")
             }
-            val destination = "$directoryPath/$file"
-            // .backup は sqlite3 コマンドのためSQL経由では使えない
-            sqlDriver.execute(null, "VACUUM INTO ?", 1) {
-                bindString(1, destination)
+            withDatabase { sqlDriver, _ ->
+                require(!file.contains(Files.separator)) { "file contains separator: $file" }
+                if (!Files.exists(directoryPath)) {
+                    Files.mkdirs(directoryPath)
+                }
+                val destination = "$directoryPath/$file"
+                // .backup は sqlite3 コマンドのためSQL経由では使えない
+                sqlDriver.execute(null, "VACUUM INTO ?", 1) {
+                    bindString(1, destination)
+                }
             }
         }
     }
 
     override suspend fun getDatabaseStatus(): String = withContext(dispatcher) {
-        withDatabase { sqlDriver, database ->
-            database.transactionWithResult {
-                //val userVersion = database.pragmaQueries.getUserVersion()
-                //val journalMode = database.pragmaQueries.getJournalMode()
-                //val synchronous = database.pragmaQueries.getSynchronous()
-                //val autoVacuum = database.pragmaQueries.getAutoVacuum()
-                //val lockingMode = database.pragmaQueries.getLockingMode()
-                // Good: WAL + synchronous = NORMAL(1)
-                val journalMode = sqlDriver.executeQuery(null, "PRAGMA journal_mode", 0).use {
-                    if (it.next()) {
-                        it.getString(0)
-                    } else null
-                }
-                val journalSizeLimit =
-                    sqlDriver.executeQuery(null, "PRAGMA journal_size_limit", 0).use {
+        mutex.withLock {
+            if (closed) {
+                error("Database connection is closed")
+            }
+            withDatabase { sqlDriver, database ->
+                database.transactionWithResult {
+                    //val userVersion = database.pragmaQueries.getUserVersion()
+                    //val journalMode = database.pragmaQueries.getJournalMode()
+                    //val synchronous = database.pragmaQueries.getSynchronous()
+                    //val autoVacuum = database.pragmaQueries.getAutoVacuum()
+                    //val lockingMode = database.pragmaQueries.getLockingMode()
+                    // Good: WAL + synchronous = NORMAL(1)
+                    val journalMode = sqlDriver.executeQuery(null, "PRAGMA journal_mode", 0).use {
+                        if (it.next()) {
+                            it.getString(0)
+                        } else null
+                    }
+                    val journalSizeLimit =
+                        sqlDriver.executeQuery(null, "PRAGMA journal_size_limit", 0).use {
+                            if (it.next()) {
+                                it.getLong(0)
+                            } else null
+                        }
+                    val walAutoCheckpoint =
+                        sqlDriver.executeQuery(null, "PRAGMA wal_autocheckpoint", 0).use {
+                            if (it.next()) {
+                                it.getLong(0)
+                            } else null
+                        }
+                    val synchronous = sqlDriver.executeQuery(null, "PRAGMA synchronous", 0).use {
                         if (it.next()) {
                             it.getLong(0)
                         } else null
                     }
-                val walAutoCheckpoint =
-                    sqlDriver.executeQuery(null, "PRAGMA wal_autocheckpoint", 0).use {
+                    val tempStore = sqlDriver.executeQuery(null, "PRAGMA temp_store", 0).use {
                         if (it.next()) {
                             it.getLong(0)
                         } else null
                     }
-                val synchronous = sqlDriver.executeQuery(null, "PRAGMA synchronous", 0).use {
-                    if (it.next()) {
-                        it.getLong(0)
-                    } else null
+                    val memoryMapSize = sqlDriver.executeQuery(null, "PRAGMA mmap_size", 0).use {
+                        if (it.next()) {
+                            it.getLong(0)
+                        } else null
+                    }
+                    val autoVacuum = sqlDriver.executeQuery(null, "PRAGMA auto_vacuum", 0).use {
+                        if (it.next()) {
+                            it.getLong(0)
+                        } else null
+                    }
+                    val lockingMode = sqlDriver.executeQuery(null, "PRAGMA locking_mode", 0).use {
+                        if (it.next()) {
+                            it.getString(0)
+                        } else null
+                    }
+                    val maxPageCount =
+                        sqlDriver.executeQuery(null, "PRAGMA max_page_count", 0).use {
+                            if (it.next()) {
+                                it.getLong(0)
+                            } else null
+                        }
+                    val cacheSize = sqlDriver.executeQuery(null, "PRAGMA cache_size", 0).use {
+                        if (it.next()) {
+                            it.getLong(0)
+                        } else null
+                    }
+                    val pageSize = sqlDriver.executeQuery(null, "PRAGMA page_size", 0).use {
+                        if (it.next()) {
+                            it.getLong(0)
+                        } else null
+                    }
+                    val busyTimeout = sqlDriver.executeQuery(null, "PRAGMA busy_timeout", 0).use {
+                        if (it.next()) {
+                            it.getLong(0)
+                        } else null
+                    }
+                    val secureDelete = sqlDriver.executeQuery(null, "PRAGMA secure_delete", 0).use {
+                        if (it.next()) {
+                            it.getString(0)
+                        } else null
+                    }
+                    val userVersion = sqlDriver.executeQuery(null, "PRAGMA user_version", 0).use {
+                        if (it.next()) {
+                            it.getLong(0)
+                        } else null
+                    }
+                    val freelistCount =
+                        sqlDriver.executeQuery(null, "PRAGMA freelist_count", 0).use {
+                            if (it.next()) {
+                                it.getLong(0)
+                            } else null
+                        }
+                    """
+                    --- configs:
+                    journal_mode = $journalMode (DELETE | TRUNCATE | PERSIST | MEMORY | WAL | OFF)
+                    journal_size_limit = $journalSizeLimit (bytes, negative = no limit, 0 = truncate to minimum)
+                    wal_autocheckpoint = $walAutoCheckpoint (pages)
+                    synchronous = $synchronous (0 = OFF, 1 = NORMAL, 2 = FULL, 3 = EXTRA)
+                    temp_store = $tempStore (0 = DEFAULT, 1 = FILE, 2 = MEMORY)
+                    mmap_size = $memoryMapSize (bytes)
+                    auto_vacuum = $autoVacuum (0 = NONE, 1 = FULL, 2 = INCREMENTAL)
+                    locking_mode = $lockingMode (NORMAL | EXCLUSIVE)
+                    max_page_count = $maxPageCount (pages)
+                    cache_size = $cacheSize (negative = KiB, positive = pages)
+                    page_size = $pageSize (bytes)
+                    busy_timeout = $busyTimeout (milliseconds)
+                    secure_delete = $secureDelete (0 = OFF, 1 = ON, 2 = FAST)
+                    --- stats:
+                    user_version = $userVersion
+                    freelist_count = $freelistCount (pages)
+                    """.trimIndent()
                 }
-                val tempStore = sqlDriver.executeQuery(null, "PRAGMA temp_store", 0).use {
-                    if (it.next()) {
-                        it.getLong(0)
-                    } else null
+            }
+        }
+    }
+
+    override suspend fun close() = withContext(dispatcher) {
+        mutex.withLock {
+            if (!closed) {
+                withDatabase { sqlDriver, _ ->
+                    sqlDriver.close()
                 }
-                val memoryMapSize = sqlDriver.executeQuery(null, "PRAGMA mmap_size", 0).use {
-                    if (it.next()) {
-                        it.getLong(0)
-                    } else null
-                }
-                val autoVacuum = sqlDriver.executeQuery(null, "PRAGMA auto_vacuum", 0).use {
-                    if (it.next()) {
-                        it.getLong(0)
-                    } else null
-                }
-                val lockingMode = sqlDriver.executeQuery(null, "PRAGMA locking_mode", 0).use {
-                    if (it.next()) {
-                        it.getString(0)
-                    } else null
-                }
-                val maxPageCount = sqlDriver.executeQuery(null, "PRAGMA max_page_count", 0).use {
-                    if (it.next()) {
-                        it.getLong(0)
-                    } else null
-                }
-                val cacheSize = sqlDriver.executeQuery(null, "PRAGMA cache_size", 0).use {
-                    if (it.next()) {
-                        it.getLong(0)
-                    } else null
-                }
-                val pageSize = sqlDriver.executeQuery(null, "PRAGMA page_size", 0).use {
-                    if (it.next()) {
-                        it.getLong(0)
-                    } else null
-                }
-                val busyTimeout = sqlDriver.executeQuery(null, "PRAGMA busy_timeout", 0).use {
-                    if (it.next()) {
-                        it.getLong(0)
-                    } else null
-                }
-                val secureDelete = sqlDriver.executeQuery(null, "PRAGMA secure_delete", 0).use {
-                    if (it.next()) {
-                        it.getString(0)
-                    } else null
-                }
-                val userVersion = sqlDriver.executeQuery(null, "PRAGMA user_version", 0).use {
-                    if (it.next()) {
-                        it.getLong(0)
-                    } else null
-                }
-                val freelistCount = sqlDriver.executeQuery(null, "PRAGMA freelist_count", 0).use {
-                    if (it.next()) {
-                        it.getLong(0)
-                    } else null
-                }
-                """
-                --- configs:
-                journal_mode = $journalMode (DELETE | TRUNCATE | PERSIST | MEMORY | WAL | OFF)
-                journal_size_limit = $journalSizeLimit (bytes, negative = no limit, 0 = truncate to minimum)
-                wal_autocheckpoint = $walAutoCheckpoint (pages)
-                synchronous = $synchronous (0 = OFF, 1 = NORMAL, 2 = FULL, 3 = EXTRA)
-                temp_store = $tempStore (0 = DEFAULT, 1 = FILE, 2 = MEMORY)
-                mmap_size = $memoryMapSize (bytes)
-                auto_vacuum = $autoVacuum (0 = NONE, 1 = FULL, 2 = INCREMENTAL)
-                locking_mode = $lockingMode (NORMAL | EXCLUSIVE)
-                max_page_count = $maxPageCount (pages)
-                cache_size = $cacheSize (negative = KiB, positive = pages)
-                page_size = $pageSize (bytes)
-                busy_timeout = $busyTimeout (milliseconds)
-                secure_delete = $secureDelete (0 = OFF, 1 = ON, 2 = FAST)
-                --- stats:
-                user_version = $userVersion
-                freelist_count = $freelistCount (pages)
-                """.trimIndent()
+                closed = true
             }
         }
     }

--- a/kottage/src/commonSqliteMain/kotlin/io/github/irgaly/kottage/internal/database/SqliteDatabaseConnectionFactory.kt
+++ b/kottage/src/commonSqliteMain/kotlin/io/github/irgaly/kottage/internal/database/SqliteDatabaseConnectionFactory.kt
@@ -8,6 +8,7 @@ import io.github.irgaly.kottage.data.sqlite.KottageDatabase
 import io.github.irgaly.kottage.data.sqlite.createDriver
 import io.github.irgaly.kottage.platform.Files
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.withContext
 
 internal class SqliteDatabaseConnectionFactory: DatabaseConnectionFactory {
@@ -15,6 +16,7 @@ internal class SqliteDatabaseConnectionFactory: DatabaseConnectionFactory {
         fileName: String,
         directoryPath: String,
         environment: KottageEnvironment,
+        scope: CoroutineScope,
         dispatcher: CoroutineDispatcher
     ): DatabaseConnection {
         require(!fileName.contains(Files.separator)) { "fileName contains separator: $fileName" }
@@ -28,7 +30,7 @@ internal class SqliteDatabaseConnectionFactory: DatabaseConnectionFactory {
             ).createDriver(fileName, directoryPath)
         }, { sqlDriver ->
             KottageDatabase(sqlDriver, Item_event.Adapter(EnumColumnAdapter()))
-        }, dispatcher)
+        }, scope, dispatcher)
     }
 
     override suspend fun createOldDatabase(
@@ -36,6 +38,7 @@ internal class SqliteDatabaseConnectionFactory: DatabaseConnectionFactory {
         directoryPath: String,
         environment: KottageEnvironment,
         version: Int,
+        scope: CoroutineScope,
         dispatcher: CoroutineDispatcher
     ) {
         withContext(dispatcher) {

--- a/kottage/src/commonTest/kotlin/io/github/irgaly/kottage/KottageMigrationTest.kt
+++ b/kottage/src/commonTest/kotlin/io/github/irgaly/kottage/KottageMigrationTest.kt
@@ -13,7 +13,7 @@ class KottageMigrationTest : KottageSpec("migration", body = {
             val environment = KottageEnvironment(KottageContext(), calendar)
             it("from 1") {
                 Kottage.createOldDatabase("v1", tempDirectory, environment, 1)
-                val kottage = Kottage("v1", tempDirectory, environment)
+                val kottage = Kottage("v1", tempDirectory, environment, specScope)
                 val cache = kottage.cache("cache1")
                 cache.put("key2", "value2")
                 cache.get<String>("key1") shouldBe "value1"
@@ -21,7 +21,7 @@ class KottageMigrationTest : KottageSpec("migration", body = {
             }
             it("from 2") {
                 Kottage.createOldDatabase("v2", tempDirectory, environment, 2)
-                val kottage = Kottage("v2", tempDirectory, environment)
+                val kottage = Kottage("v2", tempDirectory, environment, specScope)
                 val cache = kottage.cache("cache1")
                 cache.put("key2", "value2")
                 cache.get<String>("key1") shouldBe "value1"

--- a/kottage/src/commonTest/kotlin/io/github/irgaly/kottage/KottageTest.kt
+++ b/kottage/src/commonTest/kotlin/io/github/irgaly/kottage/KottageTest.kt
@@ -8,15 +8,20 @@ import io.github.irgaly.kottage.platform.KottageContext
 import io.github.irgaly.kottage.platform.TestCalendar
 import io.github.irgaly.kottage.property.KottageStore
 import io.github.irgaly.kottage.test.KottageSpec
+import io.kotest.assertions.retry
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldNotBeEmpty
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotlin.experimental.xor
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 class KottageTest : KottageSpec("kottage", body = {
     describe("Kottage") {
@@ -69,7 +74,8 @@ class KottageTest : KottageSpec("kottage", body = {
                         KottageEnvironment(
                             KottageContext(),
                             TestCalendar(DateTime(2022, 1, 1).utc)
-                        )
+                        ),
+                        specScope
                     ).storage("test").put("test", "test")
                 }
             }
@@ -81,7 +87,8 @@ class KottageTest : KottageSpec("kottage", body = {
                         KottageEnvironment(
                             KottageContext(),
                             TestCalendar(DateTime(2022, 1, 1).utc)
-                        )
+                        ),
+                        specScope
                     ).storage("test").put("test", "test")
                 }
             }
@@ -93,7 +100,8 @@ class KottageTest : KottageSpec("kottage", body = {
                         KottageEnvironment(
                             KottageContext(),
                             TestCalendar(DateTime(2022, 1, 1).utc)
-                        )
+                        ),
+                        specScope
                     )
                 }
             }
@@ -101,7 +109,7 @@ class KottageTest : KottageSpec("kottage", body = {
         context("Connection") {
             it("ディレクトリが存在しなくてもファイルを作成できる") {
                 val directory = "$tempDirectory/subdirectory"
-                val subdirectoryKottage = buildKottage("test", directory).first
+                val subdirectoryKottage = buildKottage("test", directory, specScope).first
                 val storage = subdirectoryKottage.storage("storage1")
                 shouldNotThrowAny {
                     storage.put("key", "test")
@@ -116,6 +124,21 @@ class KottageTest : KottageSpec("kottage", body = {
                 kottage.closed shouldBe true
                 shouldThrow<IllegalStateException> {
                     storage.get<String>("test")
+                }
+            }
+            it("scope 終了で close される") {
+                val scope = CoroutineScope(Dispatchers.Default)
+                val kottage = kottage("scope_close", scope).first
+                val storage = kottage.storage("test")
+                storage.put("test", "test")
+                kottage.closed shouldBe false
+                scope.cancel()
+                retry(10, 10.seconds, delay = 100.milliseconds) {
+                    // GlobalScope で Kottage.close() が処理されるため、処理完了まで非同期で待つ
+                    kottage.closed shouldBe true
+                    shouldThrow<IllegalStateException> {
+                        storage.get<String>("test")
+                    }
                 }
             }
         }

--- a/kottage/src/commonTest/kotlin/io/github/irgaly/kottage/KottageTest.kt
+++ b/kottage/src/commonTest/kotlin/io/github/irgaly/kottage/KottageTest.kt
@@ -99,12 +99,23 @@ class KottageTest : KottageSpec("kottage", body = {
             }
         }
         context("Connection") {
-            val directory = "$tempDirectory/subdirectory"
-            val subdirectoryKottage = buildKottage("test", directory).first
-            val storage = subdirectoryKottage.storage("storage1")
             it("ディレクトリが存在しなくてもファイルを作成できる") {
+                val directory = "$tempDirectory/subdirectory"
+                val subdirectoryKottage = buildKottage("test", directory).first
+                val storage = subdirectoryKottage.storage("storage1")
                 shouldNotThrowAny {
                     storage.put("key", "test")
+                }
+            }
+            it("close() 後は IllegalStateException") {
+                val kottage = kottage("connection_close").first
+                val storage = kottage.storage("test")
+                storage.put("test", "test")
+                kottage.closed shouldBe false
+                kottage.close()
+                kottage.closed shouldBe true
+                shouldThrow<IllegalStateException> {
+                    storage.get<String>("test")
                 }
             }
         }

--- a/kottage/src/commonTest/kotlin/io/github/irgaly/kottage/extension/Extensions.kt
+++ b/kottage/src/commonTest/kotlin/io/github/irgaly/kottage/extension/Extensions.kt
@@ -6,6 +6,7 @@ import io.github.irgaly.kottage.Kottage
 import io.github.irgaly.kottage.KottageEnvironment
 import io.github.irgaly.kottage.KottageOptions
 import io.github.irgaly.kottage.platform.KottageContext
+import io.github.irgaly.kottage.platform.KottageLogger
 import io.github.irgaly.kottage.platform.TestCalendar
 import kotlinx.coroutines.CoroutineScope
 
@@ -16,7 +17,19 @@ fun buildKottage(
     builder: (KottageOptions.Builder.() -> Unit)? = null
 ): Pair<Kottage, TestCalendar> {
     val calendar = TestCalendar(DateTime(2022, 1, 1).utc - 1.milliseconds)
-    val environment = KottageEnvironment(KottageContext(), calendar)
+    val environment = KottageEnvironment(
+        KottageContext(),
+        calendar,
+        object : KottageLogger {
+            override suspend fun debug(message: String) {
+                println("KottageLogger DEBUG: $message")
+            }
+
+            override suspend fun error(message: String) {
+                println("KottageLogger ERROR: $message")
+            }
+        }
+    )
     val kottage = Kottage(name, directory, environment, scope, optionsBuilder = builder)
     // 初回の Event Flow が流れるようにするために、インスタンス生成後に時間を進める
     calendar.now += 1.milliseconds

--- a/kottage/src/commonTest/kotlin/io/github/irgaly/kottage/extension/Extensions.kt
+++ b/kottage/src/commonTest/kotlin/io/github/irgaly/kottage/extension/Extensions.kt
@@ -7,13 +7,17 @@ import io.github.irgaly.kottage.KottageEnvironment
 import io.github.irgaly.kottage.KottageOptions
 import io.github.irgaly.kottage.platform.KottageContext
 import io.github.irgaly.kottage.platform.TestCalendar
+import kotlinx.coroutines.CoroutineScope
 
 fun buildKottage(
-    name: String, directory: String, builder: (KottageOptions.Builder.() -> Unit)? = null
+    name: String,
+    directory: String,
+    scope: CoroutineScope,
+    builder: (KottageOptions.Builder.() -> Unit)? = null
 ): Pair<Kottage, TestCalendar> {
     val calendar = TestCalendar(DateTime(2022, 1, 1).utc - 1.milliseconds)
     val environment = KottageEnvironment(KottageContext(), calendar)
-    val kottage = Kottage(name, directory, environment, optionsBuilder = builder)
+    val kottage = Kottage(name, directory, environment, scope, optionsBuilder = builder)
     // 初回の Event Flow が流れるようにするために、インスタンス生成後に時間を進める
     calendar.now += 1.milliseconds
     return Pair(kottage, calendar)

--- a/sample/android/src/main/kotlin/io/github/irgaly/kottage/sample/MainActivity.kt
+++ b/sample/android/src/main/kotlin/io/github/irgaly/kottage/sample/MainActivity.kt
@@ -7,6 +7,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
@@ -40,11 +41,13 @@ class MainActivity : AppCompatActivity() {
             MaterialTheme {
                 val navController = rememberNavController()
                 val context = LocalContext.current
+                val scope = rememberCoroutineScope()
                 val kottage = remember(context) {
                     Kottage(
                         name = "sample",
                         directoryPath = context.cacheDir.absolutePath,
-                        KottageEnvironment(contextOf(context))
+                        KottageEnvironment(contextOf(context)),
+                        scope
                     )
                 }
                 val animalRemoteRepository = remember {
@@ -69,7 +72,8 @@ class MainActivity : AppCompatActivity() {
                     val kottage2 = Kottage(
                         "test",
                         cacheDir.absolutePath,
-                        KottageEnvironment(contextOf(baseContext))
+                        KottageEnvironment(contextOf(baseContext)),
+                        scope
                     )
                     val storage = kottage2.storage("test")
                     lifecycleScope.launch {

--- a/sample/android/src/main/kotlin/io/github/irgaly/kottage/sample/ui/PagingScreen.kt
+++ b/sample/android/src/main/kotlin/io/github/irgaly/kottage/sample/ui/PagingScreen.kt
@@ -306,7 +306,8 @@ private fun PagingScreenPreview() {
         val kottage = Kottage(
             name = "preview_dummy",
             directoryPath = "preview_dummy",
-            KottageEnvironment(contextOf(LocalContext.current))
+            KottageEnvironment(contextOf(LocalContext.current)),
+            rememberCoroutineScope()
         )
         PagingScreen(
             kottage = kottage,

--- a/sample/js-browser/src/commonMain/kotlin/io/github/irgaly/kottage/sample/Main.kt
+++ b/sample/js-browser/src/commonMain/kotlin/io/github/irgaly/kottage/sample/Main.kt
@@ -19,7 +19,7 @@ fun main() {
                 }
             }
             val environment = KottageEnvironment(KottageContext(), calendar)
-            val kottage = Kottage("name", "directory", environment) {
+            val kottage = Kottage("name", "directory", environment, this) {
 
             }
             val storage = kottage.storage("storage")

--- a/sample/js-nodejs/src/jsMain/kotlin/io/github/irgaly/kottage/sample/Main.kt
+++ b/sample/js-nodejs/src/jsMain/kotlin/io/github/irgaly/kottage/sample/Main.kt
@@ -6,24 +6,27 @@ import io.github.irgaly.kottage.get
 import io.github.irgaly.kottage.platform.KottageCalendar
 import io.github.irgaly.kottage.platform.KottageContext
 import io.github.irgaly.kottage.put
+import kotlinx.coroutines.coroutineScope
 import kotlin.js.Date
 
 suspend fun main() {
-    val fs = js("require('fs')")
-    val path = js("require('path')")
-    val os = js("require('os')")
-    val tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "")).unsafeCast<String>()
-    console.log("tempDir = $tempDir")
-    val calendar = object : KottageCalendar {
-        override fun nowUnixTimeMillis(): Long {
-            return Date.now().toLong()
+    coroutineScope {
+        val fs = js("require('fs')")
+        val path = js("require('path')")
+        val os = js("require('os')")
+        val tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "")).unsafeCast<String>()
+        console.log("tempDir = $tempDir")
+        val calendar = object : KottageCalendar {
+            override fun nowUnixTimeMillis(): Long {
+                return Date.now().toLong()
+            }
         }
+        val environment = KottageEnvironment(KottageContext(), calendar)
+        val kottage = Kottage("name", "directory", environment, this) {
+        }
+        val storage = kottage.storage("storage")
+        storage.put("key1", "value1")
+        val result = storage.get<String>("key1")
+        console.log("result = $result")
     }
-    val environment = KottageEnvironment(KottageContext(), calendar)
-    val kottage = Kottage("name", "directory", environment) {
-    }
-    val storage = kottage.storage("storage")
-    storage.put("key1", "value1")
-    val result = storage.get<String>("key1")
-    console.log("result = $result")
 }


### PR DESCRIPTION
* implements #10
* Kottage.close() で Database Connection は close されます
* Database connection の leak を防ぐために close() が必要です
    * JVM 環境は JDBC-SQLite は Transaction 終了で自動でクローズされているので、close しなくても leak の心配はありません
    * 他の環境 (Android, iOS, macOS, Windows, nodeJS, JS browser では、Database connection close が必要です
* `Kottage(... scope = ...)` で渡した scope が終了するときに、Kottage は自動で close() されます。
* Kottage.close() 後は、データベースへアクセスすると IllegalStateException が発生します
* Kottage.close() 後はその Kottage インスタンスを再利用することはできません

---

* [x] close したら scope Job の Kottage 参照を削除する
* [x] Kottage 内の GlobalScope を Kottage.scope に置き換える