### PR TITLE
Add list event on item update

### DIFF
--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageListImpl.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageListImpl.kt
@@ -563,7 +563,7 @@ internal class KottageListImpl(
         val entry = transactionWithAutoCompaction(now) { _, _ ->
             val entry = listOperator.getListItem(this, positionId = positionId)
                 ?: throw NoSuchElementException("positionId = $positionId")
-            listOperator.updateItemKey(this, entry.id, item, now)
+            listOperator.updateItemKey(this, entry, item, false, now)
             storageOperator.upsertItem(this, item, now)
             KottageListEntry.from(
                 entry = entry,
@@ -587,7 +587,7 @@ internal class KottageListImpl(
                 ?: throw NoSuchElementException("storage = ${storage.name}, key = $key")
             val entry = listOperator.getListItem(this, positionId = positionId)
                 ?: throw NoSuchElementException("positionId = $positionId")
-            listOperator.updateItemKey(this, entry.id, item, now)
+            listOperator.updateItemKey(this, entry, item, true, now)
             KottageListEntry.from(
                 entry = entry,
                 itemKey = item.key,

--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageStorageOperator.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/internal/KottageStorageOperator.kt
@@ -43,9 +43,36 @@ internal class KottageStorageOperator(
             itemListType = null,
             maxEventEntryCount = storageOptions.maxEventEntryCount
         )
+        if (!isCreate) {
+            itemListRepository.getIds(
+                transaction,
+                itemType = itemType,
+                itemKey = item.key
+            ).forEach { itemListEntryId ->
+                val entry = checkNotNull(itemListRepository.get(transaction, itemListEntryId))
+                operator.addEvent(
+                    transaction,
+                    now = now,
+                    eventType = ItemEventType.Update,
+                    eventExpireTime = storageOptions.eventExpireTime,
+                    itemType = itemType,
+                    itemKey = item.key,
+                    itemListId = entry.id,
+                    itemListType = entry.type,
+                    maxEventEntryCount = storageOptions.maxEventEntryCount
+                )
+            }
+        }
         if (isCreate) {
             val count = itemRepository.getStatsCount(transaction, item.type)
-            storageOptions.strategy.onPostItemCreate(KottageTransaction(transaction), item.key, item.type, count, now, operator)
+            storageOptions.strategy.onPostItemCreate(
+                KottageTransaction(transaction),
+                item.key,
+                item.type,
+                count,
+                now,
+                operator
+            )
         }
     }
 

--- a/kottage/src/commonTest/kotlin/io/github/irgaly/kottage/KottageEventTest.kt
+++ b/kottage/src/commonTest/kotlin/io/github/irgaly/kottage/KottageEventTest.kt
@@ -75,14 +75,50 @@ class KottageEventTest : KottageSpec("kottage_event", body = {
                 val cache = kottage.cache("event_list")
                 val list = cache.list("list_event_list")
                 cache.eventFlow().filter { it.listType != null }.test {
-                    list.add("key1", "value1")
+                    val entry1 = list.add("key1", "value1")
                     awaitItem().let {
                         it.listPositionId shouldNotBe null
                         it.listType shouldBe "list_event_list"
                         it.eventType shouldBe KottageEventType.Create
                     }
                     calendar.now += 1.seconds
-                    list.remove(checkNotNull(list.getFirst()).positionId)
+                    cache.put("key1", "value2")
+                    awaitItem().let {
+                        it.listPositionId shouldNotBe null
+                        it.listType shouldBe "list_event_list"
+                        it.eventType shouldBe KottageEventType.Update
+                    }
+                    calendar.now += 1.seconds
+                    list.update(entry1.positionId, "key2", "value2")
+                    awaitItem().let {
+                        it.listPositionId shouldNotBe null
+                        it.listType shouldBe "list_event_list"
+                        it.itemKey shouldBe "key1"
+                        it.eventType shouldBe KottageEventType.Delete
+                    }
+                    awaitItem().let {
+                        it.listPositionId shouldNotBe null
+                        it.listType shouldBe "list_event_list"
+                        it.itemKey shouldBe "key2"
+                        it.eventType shouldBe KottageEventType.Create
+                    }
+                    calendar.now += 1.seconds
+                    cache.put("key3", "value3")
+                    list.updateKey(entry1.positionId, "key3")
+                    awaitItem().let {
+                        it.listPositionId shouldNotBe null
+                        it.listType shouldBe "list_event_list"
+                        it.itemKey shouldBe "key2"
+                        it.eventType shouldBe KottageEventType.Delete
+                    }
+                    awaitItem().let {
+                        it.listPositionId shouldNotBe null
+                        it.listType shouldBe "list_event_list"
+                        it.itemKey shouldBe "key3"
+                        it.eventType shouldBe KottageEventType.Create
+                    }
+                    calendar.now += 1.seconds
+                    list.remove(entry1.positionId)
                     awaitItem().let {
                         it.listPositionId shouldNotBe null
                         it.listType shouldBe "list_event_list"


### PR DESCRIPTION
ref #107

* [x] List に含まれる Item を更新するとき List の Update イベントを発行する
* [x] KottageList.updateKey() で Key を差し替えるとき、List の Item Update イベントではなく List の Item Delete -> Item Create のイベントを発行する