### PR TITLE
fix: getPageFrom previousPositionId, nextPositionId nullability

### DIFF
--- a/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/KottageList.kt
+++ b/kottage/src/commonMain/kotlin/io/github/irgaly/kottage/KottageList.kt
@@ -33,7 +33,10 @@ interface KottageList {
     suspend fun getFirst(): KottageListEntry?
     suspend fun getLast(): KottageListEntry?
 
-    suspend fun get(positionId: String): KottageListEntry?
+    suspend fun get(
+        positionId: String,
+        direction: KottageListDirection = KottageListDirection.Forward
+    ): KottageListEntry?
 
     /**
      * Get item with iteration.

--- a/sample/android/src/main/kotlin/io/github/irgaly/kottage/sample/data/AnimalRemoteMediator.kt
+++ b/sample/android/src/main/kotlin/io/github/irgaly/kottage/sample/data/AnimalRemoteMediator.kt
@@ -72,7 +72,7 @@ class AnimalRemoteMediator(
             }
             if (loadType == LoadType.REFRESH) {
                 // clear local data when refresh is succeeded
-                list.dropList()
+                list.removeAll(true)
             }
             // store data to kottage
             page?.items?.map { animal ->

--- a/sample/android/src/main/kotlin/io/github/irgaly/kottage/sample/data/repository/AnimalRemoteRepository.kt
+++ b/sample/android/src/main/kotlin/io/github/irgaly/kottage/sample/data/repository/AnimalRemoteRepository.kt
@@ -31,7 +31,7 @@ class AnimalRemoteRepository(
     }
 
     suspend fun regenerate() {
-        list.dropList()
+        list.removeAll(true)
         val animals = generate()
         list.addAll(
             animals.map {

--- a/sample/android/src/main/kotlin/io/github/irgaly/kottage/sample/ui/PagingScreen.kt
+++ b/sample/android/src/main/kotlin/io/github/irgaly/kottage/sample/ui/PagingScreen.kt
@@ -222,7 +222,7 @@ fun PagingScreen(
                         animalSource?.clear()
                     }
                 }) {
-                    Text("KottageList.clear()")
+                    Text("KottageList.removeAll()")
                 }
                 Button(onClick = {
                     scope.launch {


### PR DESCRIPTION
* [x] add KottageList.get() direction parameter
* [x] fix: KottageList.getPageFrom(): if previous page or next page is not available, KottageListPage.previousPositionId / nextPositionId is null
* [x] fix: :sample:android : use KottageList.removeAll(true)