### PR TITLE
support watchosDeviceArm64, update SQLDelight 2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,17 +376,17 @@ val stringValue: String = storage.get("long_value") // => "value"
 Kottage is a Kotlin Multiplatform library. Please feel free to report a issue if it doesn't
 work correctly on these platforms.
 
-| Platform                          | Target                                                         | Status                                                        |
-|-----------------------------------|----------------------------------------------------------------|---------------------------------------------------------------|
-| Kotlin/JVM on Linux/macOS/Windows | jvm                                                            | :white_check_mark: Tested                                     |
-| Kotlin/JS on Linux/macOS/Windows  | browser, nodejs                                                | :white_check_mark: Tested<br/>browser on macOS Chrome, Safari |
-| Kotlin/Android                    | android                                                        | :white_check_mark: Tested                                     |
-| Kotlin/Native iOS                 | iosArm64<br>iosX64(simulator)<br>iosSimulatorArm64             | :white_check_mark: Tested                                     |
-| Kotlin/Native watchOS             | watchosArm64<br>watchosX64(simulator)<br>watchosSimulatorArm64 | :white_check_mark: (Tested as iosX64)                         |
-| Kotlin/Native tvOS                | tvosArm64<br>tvosX64(simulator)<br>tvosSimulatorArm64          | :white_check_mark: (Tested as iosX64)                         |
-| Kotlin/Native macOS               | macosArm64<br>macosX64                                         | :white_check_mark: Tested                                     |
-| Kotlin/Native Linux               | linuxX64                                                       | :white_check_mark: Tested                                     |
-| Kotlin/Native Windows             | mingwX64                                                       | :white_check_mark: Tested                                     |
+| Platform                          | Target                                                                               | Status                                                        |
+|-----------------------------------|--------------------------------------------------------------------------------------|---------------------------------------------------------------|
+| Kotlin/JVM on Linux/macOS/Windows | jvm                                                                                  | :white_check_mark: Tested                                     |
+| Kotlin/JS on Linux/macOS/Windows  | browser, nodejs                                                                      | :white_check_mark: Tested<br/>browser on macOS Chrome, Safari |
+| Kotlin/Android                    | android                                                                              | :white_check_mark: Tested                                     |
+| Kotlin/Native iOS                 | iosArm64<br>iosX64(simulator)<br>iosSimulatorArm64                                   | :white_check_mark: Tested                                     |
+| Kotlin/Native watchOS             | watchosArm64<br>watchosDeviceArm64<br>watchosX64(simulator)<br>watchosSimulatorArm64 | :white_check_mark: (Tested as iosX64)                         |
+| Kotlin/Native tvOS                | tvosArm64<br>tvosX64(simulator)<br>tvosSimulatorArm64                                | :white_check_mark: (Tested as iosX64)                         |
+| Kotlin/Native macOS               | macosArm64<br>macosX64                                                               | :white_check_mark: Tested                                     |
+| Kotlin/Native Linux               | linuxX64                                                                             | :white_check_mark: Tested                                     |
+| Kotlin/Native Windows             | mingwX64                                                                             | :white_check_mark: Tested                                     |
 
 There is also [Kottage for SwiftPM](https://github.com/irgaly/kottage-package) that is **just for
 experimental** build.

--- a/build-logic/src/main/kotlin/io/github/irgaly/buildlogic/Extensions.kt
+++ b/build-logic/src/main/kotlin/io/github/irgaly/buildlogic/Extensions.kt
@@ -4,13 +4,13 @@ import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.dsl.CommonExtension
 import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.LibraryExtension
+import java.io.ByteArrayOutputStream
 import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalog
 import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.getByType
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
-import java.io.ByteArrayOutputStream
 
 /**
  * android build 共通設定を適用する
@@ -111,6 +111,7 @@ fun Project.configureMultiplatformLibrary() {
         iosSimulatorArm64() // Apple iOS simulator on Apple Silicon platforms
         // watchOS
         watchosArm64() // Apple watchOS on ARM64_32 platforms (Apple Watch Series 4 and newer)
+        watchosDeviceArm64() // Apple watchOS on ARM64 platforms (Apple Watch Series 8 and newer)
         watchosX64() // Apple watchOS 64-bit simulator (watchOS 7.0 and newer) on x86_64 platforms
         watchosSimulatorArm64() // Apple watchOS simulator on Apple Silicon platforms
         // tvOS

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ gradle-android = "8.3.1"
 gradle-android-compile-sdk = "34"
 gradle-android-target-sdk = "34"
 gradle-android-min-sdk = "21"
-sqldelight = "2.0.0"
+sqldelight = "2.0.1"
 
 [libraries]
 gradle-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }

--- a/kottage/build.gradle.kts
+++ b/kottage/build.gradle.kts
@@ -52,6 +52,7 @@ kotlin {
     iosX64(configure = configureXcf)
     iosSimulatorArm64(configure = configureXcf)
     watchosArm64(configure = configureXcf)
+    watchosDeviceArm64(configure = configureXcf)
     watchosX64(configure = configureXcf)
     watchosSimulatorArm64(configure = configureXcf)
     tvosArm64(configure = configureXcf)


### PR DESCRIPTION
watchosDeviceArm64 を追加するために事前にやること

* [x] Kotlin 1.8.20 以降へアップデート #106
* [x] Kotlinx Serialization 1.5.1 アップデート #172
* [x] SQLDelight 2.0.0 アップデート #179
* [x] Kotest 5.8.1 へアップデート #212
    * ref: https://github.com/kotest/kotest/issues/3748
* [x] SQLDelight 2.0.1
    * bbd9ab3