### PR TITLE
Update better-sqlite 9.2.2, fix python3 3.12 ModuleNotFoundError

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -46,6 +46,11 @@ jobs:
       - name: JVM Test
         run: |
           ./gradlew jvmTest
+      - name: install python3 setuptools
+        if: matrix.platform == 'macos-11'
+        run: |
+          # https://github.com/WiseLibs/better-sqlite3/pull/1100
+          python3 -m pip install setuptools
       - name: JS Nodejs Test
         run: |
           ./gradlew jsNodeTest

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -509,13 +509,13 @@ batch@0.6.1:
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
   integrity sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==
 
-better-sqlite3@8.3.0:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-8.3.0.tgz#3873ddfd9f2af90b628657e8ff221786c93d1984"
-  integrity sha512-JTmvBZL/JLTc+3Msbvq6gK6elbU9/wVMqiudplHrVJpr7sVMR9KJrNhZAbW+RhXKlpMcuEhYkdcHa3TXKNXQ1w==
+better-sqlite3@9.2.2:
+  version "9.2.2"
+  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-9.2.2.tgz#3ce1ed24f327ed8c9b0c39b825cdc2341aeb249f"
+  integrity sha512-qwjWB46il0lsDkeB4rSRI96HyDQr8sxeu1MkBVLMrwusq1KRu4Bpt1TMI+8zIJkDUtZ3umjAkaEjIlokZKWCQw==
   dependencies:
     bindings "^1.5.0"
-    prebuild-install "^7.1.0"
+    prebuild-install "^7.1.1"
 
 binary-extensions@^2.0.0:
   version "2.2.0"
@@ -2118,7 +2118,7 @@ pkg-dir@^4.2.0:
   dependencies:
     find-up "^4.0.0"
 
-prebuild-install@^7.1.0:
+prebuild-install@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.1.1.tgz#de97d5b34a70a0c81334fd24641f2a1702352e45"
   integrity sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==

--- a/kottage/data/sqlite/build.gradle.kts
+++ b/kottage/data/sqlite/build.gradle.kts
@@ -58,8 +58,8 @@ kotlin {
         }
         val jsMain by getting {
             dependencies {
-                implementation(npm("better-sqlite3", "8.3.0"))
-                //implementation(npm("@types/better-sqlite3", "8.3.0", generateExternals = true))
+                implementation(npm("better-sqlite3", "9.2.2"))
+                //implementation(npm("@types/better-sqlite3", "9.2.2", generateExternals = true))
             }
         }
     }


### PR DESCRIPTION
python3.12でdistutilsが削除され、gypが動かなくなった問題への対応

https://github.com/WiseLibs/better-sqlite3/issues/1093