### PR TITLE
Support linuxArm64 target

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ work correctly on these platforms.
 | Kotlin/Native watchOS             | watchosArm64<br>watchosDeviceArm64<br>watchosX64(simulator)<br>watchosSimulatorArm64 | :white_check_mark: (Tested as iosX64)                         |
 | Kotlin/Native tvOS                | tvosArm64<br>tvosX64(simulator)<br>tvosSimulatorArm64                                | :white_check_mark: (Tested as iosX64)                         |
 | Kotlin/Native macOS               | macosArm64<br>macosX64                                                               | :white_check_mark: Tested                                     |
-| Kotlin/Native Linux               | linuxX64                                                                             | :white_check_mark: Tested                                     |
+| Kotlin/Native Linux               | linuxX64<br>linuxArm64                                                               | :white_check_mark: Tested (by linuxX64 only)                  |
 | Kotlin/Native Windows             | mingwX64                                                                             | :white_check_mark: Tested                                     |
 
 There is also [Kottage for SwiftPM](https://github.com/irgaly/kottage-package) that is **just for

--- a/build-logic/src/main/kotlin/io/github/irgaly/buildlogic/Extensions.kt
+++ b/build-logic/src/main/kotlin/io/github/irgaly/buildlogic/Extensions.kt
@@ -4,13 +4,13 @@ import com.android.build.api.dsl.ApplicationExtension
 import com.android.build.api.dsl.CommonExtension
 import com.android.build.gradle.BaseExtension
 import com.android.build.gradle.LibraryExtension
-import java.io.ByteArrayOutputStream
 import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalog
 import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.getByType
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import java.io.ByteArrayOutputStream
 
 /**
  * android build 共通設定を適用する
@@ -123,6 +123,7 @@ fun Project.configureMultiplatformLibrary() {
         macosArm64() // Apple macOS on Apple Silicon platforms
         // Linux
         linuxX64() // Linux on x86_64 platforms
+        linuxArm64() // Linux on ARM64 platforms
         // Windows
         mingwX64() // 64-bit Microsoft Windows
         /*


### PR DESCRIPTION
* linuxArm64 is Tier 2 https://kotlinlang.org/docs/native-target-support.html#tier-2