### PR TITLE
Gradle: remove unspecified version spec

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,10 +64,10 @@ android-application = { id = "com.android.application", version.ref = "gradle-an
 android-library = { id = "com.android.library", version.ref = "gradle-android" }
 kotest-multiplatform = { id = "io.kotest.multiplatform", version.ref = "kotest" }
 sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
-buildlogic-android-application = { id = "build-logic.android.application", version = "unspecified" }
-buildlogic-android-library = { id = "build-logic.android.library", version = "unspecified" }
-buildlogic-multiplatform-library = { id = "build-logic.multiplatform.library", version = "unspecified" }
-buildlogic-dependencygraph = { id = "build-logic.dependency-graph", version = "unspecified" }
+buildlogic-android-application = { id = "build-logic.android.application" }
+buildlogic-android-library = { id = "build-logic.android.library" }
+buildlogic-multiplatform-library = { id = "build-logic.multiplatform.library" }
+buildlogic-dependencygraph = { id = "build-logic.dependency-graph" }
 dokka = { id = "org.jetbrains.dokka", version = "2.0.0" }
 nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }
 android-junit5 = { id = "de.mannodermaus.android-junit5", version = "1.11.2.0" }


### PR DESCRIPTION
Gradle v8.11あたりからVersion Catalogのunspecified指定がエラーとなるためunspecified指定を削除する。