### PR TITLE
CI: migrate Maven Central Publishing Portal API 

### DIFF
--- a/.github/workflows/deploy_mavencentral_staging.yml
+++ b/.github/workflows/deploy_mavencentral_staging.yml
@@ -16,6 +16,10 @@ jobs:
           distribution: temurin
           java-version: 17
       - uses: ./.github/actions/gradle-cache
+      - name: Set Staging version
+        run: |
+          sed -i "" -E "s/^kottage = \"(.*)\"$/kottage = \"\\1-pr${{ github.event.pull_request.number }}.${{ github.run_number }}.${{ github.run_attempt }}\"/g" gradle/libs.versions.toml
+          grep "^kottage" gradle/libs.versions.toml
       - name: Deploy to Maven Central
         env:
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME_TOKEN }}
@@ -23,4 +27,6 @@ jobs:
           SIGNING_PGP_KEY: ${{ secrets.SIGNING_PGP_KEY }}
           SIGNING_PGP_PASSWORD: ${{ secrets.SIGNING_PGP_PASSWORD }}
         run: |
-          ./gradlew publishToSonatype closeSonatypeStagingRepository
+          # kottageではstagingリポジトリのcloseがタイムアウトするためcloseしない
+          # ./gradlew publishToSonatype closeSonatypeStagingRepository
+          ./gradlew publishToSonatype

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -170,10 +170,10 @@ plugins.withType<NodeJsRootPlugin> {
 nexusPublishing {
     repositories {
         sonatype {
-            // io.github.irgaly staging profile
-            stagingProfileId = "6c098027ed608f"
-            nexusUrl = uri("https://s01.oss.sonatype.org/service/local/")
-            snapshotRepositoryUrl = uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+            stagingProfileId = libs.versions.kottage.get()
+            nexusUrl = uri("https://ossrh-staging-api.central.sonatype.com/service/local/")
+            snapshotRepositoryUrl =
+                uri("https://central.sonatype.com/repository/maven-snapshots/")
         }
     }
 }


### PR DESCRIPTION
migrate to Maven Central Publishing Portal API

* https://central.sonatype.org/pages/ossrh-eol/

use OSSRH Staging API

* https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/