### PR TITLE
update: kotest 6.0.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 kottage = "1.9.0"
 kotlin = "2.2.0"
 kotlinx-coroutines = "1.10.1"
-kotest = "6.0.3"
+kotest = "6.0.4"
 gradle-android = "8.13.0"
 gradle-android-compile-sdk = "36"
 gradle-android-target-sdk = "36"


### PR DESCRIPTION
* https://github.com/kotest/kotest/releases/tag/v6.0.4

supports Kotlin 2.2.20