### PR TITLE
Renovate: ungroup KSP

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,9 +11,8 @@
       "enabled": false
     },
     {
-      "groupName": "Kotlin, KSP",
+      "groupName": "Kotlin",
       "matchPackageNames": [
-        "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin",
         "org.jetbrains.kotlin:*",
         "org.jetbrains.kotlin.*"
       ],


### PR DESCRIPTION
KSPはKotlinとは別のバージョニングとなるためKotlinとのグルーピングを解除