### PR TITLE
Renovate: remove docker gcc ignoring

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,16 +21,6 @@
         "patch"
       ],
       "enabled": true
-    },
-    {
-      "groupName": "docker gcc",
-      "enabled": false,
-      "matchPackageNames": [
-        "gcc"
-      ],
-      "matchDatasources": [
-        "docker"
-      ]
     }
   ]
 }


### PR DESCRIPTION
* GitHub Actionsでdocker gccは使わなくなったため設定を削除