### PR TITLE
refactor: Indexeddb: support openCursor autoContinue parameter

### DIFF
--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/extension/IndexxeddbExtension.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/extension/IndexxeddbExtension.kt
@@ -28,7 +28,7 @@ internal suspend fun <Item, PrimaryKey, SortKey> Queryable.iterateWithChunk(
         var consumedKeys = mapOf<SortKey, Set<PrimaryKey>>()
         var nextRange = initialRange
         while (takeNext) {
-            val results = openCursor(nextRange).map { cursor ->
+            val results = openCursor(nextRange, autoContinue = true).map { cursor ->
                 cursor.value.unsafeCast<Item>()
             }.filter {
                 // すでに処理した項目はスキップする
@@ -80,7 +80,7 @@ internal suspend fun <Item, PrimaryKey> Queryable.deleteWithChunk(
         var takeNext = true
         var deleted = 0L
         while (takeNext) {
-            val results = openCursor(query)
+            val results = openCursor(query, autoContinue = true)
                 .take(
                     limit?.let { (it - deleted).coerceAtMost(chunkSize) } ?: chunkSize
                 ).map {

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemEventRepository.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemEventRepository.kt
@@ -103,7 +103,8 @@ internal class KottageIndexeddbItemEventRepository : KottageItemEventRepository 
             store.index("item_event_created_at")
                 .openCursor(
                     // created_at DESC
-                    direction = Cursor.Direction.Previous
+                    direction = Cursor.Direction.Previous,
+                    autoContinue = true,
                 ).map { cursor ->
                     cursor.value.unsafeCast<Item_event>().created_at.toLong()
                 }.firstOrNull()
@@ -176,9 +177,11 @@ internal class KottageIndexeddbItemEventRepository : KottageItemEventRepository 
                 bound(
                     arrayOf(itemType),
                     arrayOf(itemType, emptyArray<Any>())
-                )
+                ),
+                autoContinue = false,
             ).take(limit).collect { cursor ->
                 cursor.delete()
+                cursor.`continue`()
             }
         }
     }
@@ -187,9 +190,11 @@ internal class KottageIndexeddbItemEventRepository : KottageItemEventRepository 
         transaction.store { store ->
             store.index("item_event_created_at").openCursor(
                 // created_at < createdAt
-                upperBound(createdAt.toDouble(), true)
+                upperBound(createdAt.toDouble(), true),
+                autoContinue = false,
             ).collect { cursor ->
                 cursor.delete()
+                cursor.`continue`()
             }
         }
     }
@@ -201,9 +206,11 @@ internal class KottageIndexeddbItemEventRepository : KottageItemEventRepository 
                 bound(
                     arrayOf(itemType),
                     arrayOf(itemType, emptyArray<Any>())
-                )
+                ),
+                autoContinue = false,
             ).collect { cursor ->
                 cursor.delete()
+                cursor.`continue`()
             }
         }
     }
@@ -215,9 +222,11 @@ internal class KottageIndexeddbItemEventRepository : KottageItemEventRepository 
                 bound(
                     arrayOf(listType),
                     arrayOf(listType, emptyArray<Any>())
-                )
+                ),
+                autoContinue = false,
             ).collect { cursor ->
                 cursor.delete()
+                cursor.`continue`()
             }
         }
     }

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemListRepository.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemListRepository.kt
@@ -4,8 +4,8 @@ import com.juul.indexeddb.Key
 import com.juul.indexeddb.ObjectStore
 import com.juul.indexeddb.WriteTransaction
 import com.juul.indexeddb.bound
-import com.juul.indexeddb.only
 import com.juul.indexeddb.lowerBound
+import com.juul.indexeddb.only
 import io.github.irgaly.kottage.data.indexeddb.extension.jso
 import io.github.irgaly.kottage.data.indexeddb.schema.entity.Item_list
 import io.github.irgaly.kottage.data.indexeddb.schema.entity.Item_list_stats
@@ -153,7 +153,8 @@ internal class KottageIndexeddbItemListRepository : KottageItemListRepository {
                         arrayOf(type),
                         arrayOf(type, beforeExpireAt.toDouble()),
                         upperOpen = true
-                    )
+                    ),
+                    autoContinue = true,
                 )
             } else {
                 store.index("item_list_type_expire_at").openCursor(
@@ -161,7 +162,8 @@ internal class KottageIndexeddbItemListRepository : KottageItemListRepository {
                     bound(
                         arrayOf(type),
                         arrayOf(type, emptyArray<Any>())
-                    )
+                    ),
+                    autoContinue = true,
                 )
             }).map { cursor ->
                 cursor.value.unsafeCast<Item_list>()
@@ -185,7 +187,8 @@ internal class KottageIndexeddbItemListRepository : KottageItemListRepository {
     ): Long {
         return transaction.store { store ->
             store.index("item_list_type").openCursor(
-                Key(type)
+                Key(type),
+                autoContinue = true,
             ).count { cursor ->
                 (cursor.value.unsafeCast<Item_list>().item_key == null)
             }.toLong()
@@ -224,9 +227,11 @@ internal class KottageIndexeddbItemListRepository : KottageItemListRepository {
                 bound(
                     arrayOf(type),
                     arrayOf(type, emptyArray<Any>())
-                )
+                ),
+                autoContinue = false,
             ).collect { cursor ->
                 cursor.delete()
+                cursor.`continue`()
             }
         }
     }

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemRepository.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbItemRepository.kt
@@ -240,7 +240,7 @@ internal class KottageIndexeddbItemRepository : KottageItemRepository {
     ): List<ItemStats> {
         return transaction.statsStore { store ->
             // SQLite 側に合わせて index なしで総当たり処理
-            store.openCursor().map { cursor ->
+            store.openCursor(autoContinue = true).map { cursor ->
                 cursor.value.unsafeCast<Item_stats>()
             }.filter { stats ->
                 ((stats.count.toLong() <= 0L) && (stats.event_count.toLong() <= 0))
@@ -260,9 +260,11 @@ internal class KottageIndexeddbItemRepository : KottageItemRepository {
         transaction.store { store ->
             store.index("item_type").openCursor(
                 // type = itemType
-                Key(itemType)
+                Key(itemType),
+                autoContinue = false,
             ).collect { cursor ->
                 cursor.delete()
+                cursor.`continue`()
             }
         }
     }

--- a/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbRepositoryFactory.kt
+++ b/kottage/src/commonIndexeddbMain/kotlin/io/github/irgaly/kottage/internal/repository/KottageIndexeddbRepositoryFactory.kt
@@ -10,11 +10,6 @@ package io.github.irgaly.kottage.internal.repository
  *     * external types https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.js/-js-export/
  * * Kotlin indexeddb
  *     * https://github.com/JuulLabs/indexeddb
- *     * v0.3.0 Issue
- *         * cursor Flow の collect 内で他の indexxeddb 非同期処理を実行すると
- *           collect 処理が最後まで進む前に cursor.continue() が実行され、次の collect 処理が並列で走ってしまう
- *         * Transaction 内の並列処理は整合性が保てないため、cursor Flow 内では非同期処理を使わないようにする
- *         * 例外として: cursor.delete() だけの実行なら許可する
  */
 internal class KottageIndexeddbRepositoryFactory: KottageRepositoryFactory {
     override suspend fun createItemRepository(): KottageItemRepository {


### PR DESCRIPTION
* migrate openCursor autoContinue parameter
    * ref: JuulLabs/indexeddb/pull/77