### PR TITLE
remove support: watchosX64, tvosX64, macosX64, iosX64

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,17 +383,17 @@ val stringValue: String = storage.get("long_value") // => "value"
 Kottage is a Kotlin Multiplatform library. Please feel free to report a issue if it doesn't
 work correctly on these platforms.
 
-| Platform                          | Target                                                                               | Status                                                        |
-|-----------------------------------|--------------------------------------------------------------------------------------|---------------------------------------------------------------|
-| Kotlin/JVM on Linux/macOS/Windows | jvm                                                                                  | :white_check_mark: Tested                                     |
-| Kotlin/JS on Linux/macOS/Windows  | browser, nodejs                                                                      | :white_check_mark: Tested<br/>browser on macOS Chrome, Safari |
-| Kotlin/Android                    | android                                                                              | :white_check_mark: Tested                                     |
-| Kotlin/Native iOS                 | iosArm64<br>iosX64(simulator)<br>iosSimulatorArm64                                   | :white_check_mark: Tested (by iosSimulatorArm64 only)         |
-| Kotlin/Native watchOS             | watchosArm64<br>watchosDeviceArm64<br>watchosX64(simulator)<br>watchosSimulatorArm64 | :white_check_mark: (Tested as iosSimulatorArm64)              |
-| Kotlin/Native tvOS                | tvosArm64<br>tvosX64(simulator)<br>tvosSimulatorArm64                                | :white_check_mark: (Tested as iosSimulatorArm64)              |
-| Kotlin/Native macOS               | macosArm64<br>macosX64                                                               | :white_check_mark: Tested (by macosArm64 only)                |
-| Kotlin/Native Linux               | linuxX64<br>linuxArm64                                                               | :white_check_mark: Tested (by linuxX64 only)                  |
-| Kotlin/Native Windows             | mingwX64                                                                             | :white_check_mark: Tested                                     |
+| Platform                          | Target                                                      | Status                                                        |
+|-----------------------------------|-------------------------------------------------------------|---------------------------------------------------------------|
+| Kotlin/JVM on Linux/macOS/Windows | jvm                                                         | :white_check_mark: Tested                                     |
+| Kotlin/JS on Linux/macOS/Windows  | browser, nodejs                                             | :white_check_mark: Tested<br/>browser on macOS Chrome, Safari |
+| Kotlin/Android                    | android                                                     | :white_check_mark: Tested                                     |
+| Kotlin/Native iOS                 | iosArm64<br>iosX64(simulator)<br>iosSimulatorArm64          | :white_check_mark: Tested (by iosSimulatorArm64 only)         |
+| Kotlin/Native watchOS             | watchosArm64<br>watchosDeviceArm64<br>watchosSimulatorArm64 | :white_check_mark: (Tested as iosSimulatorArm64)              |
+| Kotlin/Native tvOS                | tvosArm64<br>tvosSimulatorArm64                             | :white_check_mark: (Tested as iosSimulatorArm64)              |
+| Kotlin/Native macOS               | macosArm64                                                  | :white_check_mark: Tested (by macosArm64 only)                |
+| Kotlin/Native Linux               | linuxX64<br>linuxArm64                                      | :white_check_mark: Tested (by linuxX64 only)                  |
+| Kotlin/Native Windows             | mingwX64                                                    | :white_check_mark: Tested                                     |
 
 There is also [Kottage for SwiftPM](https://github.com/irgaly/kottage-package) that is **just for
 experimental** build.

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ work correctly on these platforms.
 | Kotlin/JVM on Linux/macOS/Windows | jvm                                                         | :white_check_mark: Tested                                     |
 | Kotlin/JS on Linux/macOS/Windows  | browser, nodejs                                             | :white_check_mark: Tested<br/>browser on macOS Chrome, Safari |
 | Kotlin/Android                    | android                                                     | :white_check_mark: Tested                                     |
-| Kotlin/Native iOS                 | iosArm64<br>iosX64(simulator)<br>iosSimulatorArm64          | :white_check_mark: Tested (by iosSimulatorArm64 only)         |
+| Kotlin/Native iOS                 | iosArm64<br>iosSimulatorArm64                               | :white_check_mark: Tested (by iosSimulatorArm64 only)         |
 | Kotlin/Native watchOS             | watchosArm64<br>watchosDeviceArm64<br>watchosSimulatorArm64 | :white_check_mark: (Tested as iosSimulatorArm64)              |
 | Kotlin/Native tvOS                | tvosArm64<br>tvosSimulatorArm64                             | :white_check_mark: (Tested as iosSimulatorArm64)              |
 | Kotlin/Native macOS               | macosArm64                                                  | :white_check_mark: Tested (by macosArm64 only)                |

--- a/build-logic/src/main/kotlin/io/github/irgaly/buildlogic/Extensions.kt
+++ b/build-logic/src/main/kotlin/io/github/irgaly/buildlogic/Extensions.kt
@@ -115,7 +115,6 @@ fun Project.configureMultiplatformLibrary() {
         jvm()
         // iOS
         iosArm64() // Apple iOS on ARM64 platforms (Apple iPhone 5s and newer)
-        iosX64() // Apple iOS simulator on x86_64 platforms
         iosSimulatorArm64() // Apple iOS simulator on Apple Silicon platforms
         // watchOS
         watchosArm64() // Apple watchOS on ARM64_32 platforms (Apple Watch Series 4 and newer)

--- a/build-logic/src/main/kotlin/io/github/irgaly/buildlogic/Extensions.kt
+++ b/build-logic/src/main/kotlin/io/github/irgaly/buildlogic/Extensions.kt
@@ -120,14 +120,11 @@ fun Project.configureMultiplatformLibrary() {
         // watchOS
         watchosArm64() // Apple watchOS on ARM64_32 platforms (Apple Watch Series 4 and newer)
         watchosDeviceArm64() // Apple watchOS on ARM64 platforms (Apple Watch Series 8 and newer)
-        watchosX64() // Apple watchOS 64-bit simulator (watchOS 7.0 and newer) on x86_64 platforms
         watchosSimulatorArm64() // Apple watchOS simulator on Apple Silicon platforms
         // tvOS
         tvosArm64() // Apple tvOS on ARM64 platforms (Apple TV 4th generation and newer)
-        tvosX64() // Apple tvOS simulator on x86_64 platforms
         tvosSimulatorArm64() // Apple tvOS simulator on Apple Silicon platforms
         // macOS
-        macosX64() // Apple macOS on x86_64 platforms
         macosArm64() // Apple macOS on Apple Silicon platforms
         // Linux
         linuxX64() // Linux on x86_64 platforms

--- a/kottage/build.gradle.kts
+++ b/kottage/build.gradle.kts
@@ -51,7 +51,6 @@ kotlin {
         }
     }
     iosArm64(configure = configureXcf)
-    iosX64(configure = configureXcf)
     iosSimulatorArm64(configure = configureXcf)
     watchosArm64(configure = configureXcf)
     watchosDeviceArm64(configure = configureXcf)

--- a/kottage/build.gradle.kts
+++ b/kottage/build.gradle.kts
@@ -55,10 +55,8 @@ kotlin {
     iosSimulatorArm64(configure = configureXcf)
     watchosArm64(configure = configureXcf)
     watchosDeviceArm64(configure = configureXcf)
-    watchosX64(configure = configureXcf)
     watchosSimulatorArm64(configure = configureXcf)
     tvosArm64(configure = configureXcf)
-    tvosX64(configure = configureXcf)
     tvosSimulatorArm64(configure = configureXcf)
     macosArm64(configure = configureXcf)
     // JS


### PR DESCRIPTION
* remove watchosX64, tvosX64, macosX64 support
* remove iosX64

https://kotlinlang.org/docs/native-target-support.html#deprecated-targets

<img width="926" height="283" alt="image" src="https://github.com/user-attachments/assets/133eb48f-01f8-440d-842e-acb23bdd60bd" />

https://kotlinlang.org/docs/whatsnew2320.html#breaking-changes-and-deprecations

<img width="817" height="244" alt="image" src="https://github.com/user-attachments/assets/6a31d441-10a2-481a-afb9-422e1ce33161" />
