### PR TITLE
remove android-junit-framework, use JUnit4 on Android DeviceTest

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -104,6 +104,7 @@ jobs:
           path: |
             **/build/test-results/*/*.xml
             **/build/reports/tests/*
+            **/build/reports/androidTests/*
   publish-test-results:
     needs: build-test
     runs-on: ubuntu-latest

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -72,7 +72,9 @@ jobs:
         uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2.37.0
         if: contains(matrix.platform, 'ubuntu')
         with:
-          api-level: 29
+          api-level: 30
+          target: google_apis
+          arch: x86_64
           script: ./gradlew connectedDebugAndroidTest
       - name: Linux Test
         if: contains(matrix.platform, 'ubuntu')

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,11 @@ subprojects {
                                 implementation(libs.test.kotest.runner)
                             }
                         }
+                        findByName("androidInstrumentedTest")?.apply {
+                            dependencies {
+                                implementation(libs.bundles.test.android.devicetest)
+                            }
+                        }
                     }
                 }
             }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,6 @@ gradle-android-compile-sdk = "37"
 gradle-android-target-sdk = "37"
 gradle-android-min-sdk = "26"
 sqldelight = "2.3.2"
-junit5-android-test = "1.9.0"
 
 [libraries]
 gradle-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
@@ -29,11 +28,9 @@ compose-uiTooling = { module = "androidx.compose.ui:ui-tooling" }
 compose-paging = { module = "androidx.paging:paging-compose", version = "3.4.2" }
 compose-navigation = { module = "androidx.navigation:navigation-compose", version = "2.9.1" }
 test-kotest-runner = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
+test-kotest-runner-junit4 = { module = "io.kotest:kotest-runner-junit4", version.ref = "kotest" }
 test-kotest-assertions = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 test-kotest-engine = { module = "io.kotest:kotest-framework-engine", version.ref = "kotest" }
-test-android-junit5 = { module = "org.junit.jupiter:junit-jupiter-api", version = "5.14.2" }
-test-android-junit5-core = { module = "de.mannodermaus.junit5:android-test-core", version.ref = "junit5-android-test" }
-test-android-junit5-runner = { module = "de.mannodermaus.junit5:android-test-runner", version.ref = "junit5-android-test" }
 test-android-runner = { module = "androidx.test:runner", version = "1.7.0" }
 test-mockk = { module = "io.mockk:mockk", version = "1.14.4" }
 test-turbine = { module = "app.cash.turbine:turbine", version = "1.2.0" }
@@ -49,9 +46,10 @@ faker = { module = "io.github.serpro69:kotlin-faker", version = "1.16.0" }
 [bundles]
 test-common = [
     "kotlin-reflect", "kotlinx-coroutines-test", "test-kotest-engine",
-    "test-kotest-assertions", "test-turbine"]
-test-android-instrumented = [
-    "test-kotest-assertions", "test-android-junit5", "test-android-junit5-core", "test-android-runner",
+    "test-kotest-assertions", "test-turbine"
+]
+test-android-devicetest = [
+    "test-android-runner", "test-kotest-assertions", "test-kotest-runner-junit4",
     "kotlinx-coroutines-test", "test-turbine"
 ]
 compose = ["compose-material", "compose-material3", "compose-uiTooling", "compose-paging", "compose-navigation"]
@@ -72,4 +70,3 @@ buildlogic-multiplatform-library = { id = "build-logic.multiplatform.library" }
 buildlogic-dependencygraph = { id = "build-logic.dependency-graph" }
 dokka = { id = "org.jetbrains.dokka", version = "2.2.0" }
 nexus-publish = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }
-android-junit5 = { id = "de.mannodermaus.android-junit5", version = "1.14.0.0" }

--- a/kottage/build.gradle.kts
+++ b/kottage/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
     alias(libs.plugins.buildlogic.android.library)
     alias(libs.plugins.kotlinx.serialization)
     alias(libs.plugins.dokka)
-    alias(libs.plugins.android.junit5)
     alias(libs.plugins.ksp)
     alias(libs.plugins.kotest)
 }
@@ -18,8 +17,6 @@ android {
     namespace = "io.github.irgaly.kottage"
     defaultConfig {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        testInstrumentationRunnerArguments["runnerBuilder"] =
-            "de.mannodermaus.junit5.AndroidJUnit5Builder"
     }
     testOptions {
         managedDevices {
@@ -118,9 +115,6 @@ kotlin {
         }
         val androidInstrumentedTest by getting {
             dependsOn(commonTest.get())
-            dependencies {
-                implementation(libs.bundles.test.android.instrumented)
-            }
         }
         val jvmMain by getting {
             dependsOn(sqliteMain)
@@ -160,10 +154,6 @@ kotlin {
             }
         }
     }
-}
-
-dependencies {
-    androidTestRuntimeOnly(libs.test.android.junit5.runner)
 }
 
 val dokkaGeneratePublicationHtml by tasks.getting(DokkaGeneratePublicationTask::class)

--- a/kottage/src/androidInstrumentedTest/kotlin/io/github/irgaly/kottage/AndroidTest.kt
+++ b/kottage/src/androidInstrumentedTest/kotlin/io/github/irgaly/kottage/AndroidTest.kt
@@ -3,48 +3,51 @@ package io.github.irgaly.kottage
 import androidx.test.platform.app.InstrumentationRegistry
 import io.github.irgaly.kottage.platform.contextOf
 import io.github.irgaly.kottage.test.KottageSpec
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.withClue
 import io.kotest.common.KotestInternal
 import io.kotest.core.spec.Spec
 import io.kotest.core.spec.SpecRef
 import io.kotest.engine.TestEngineLauncher
 import io.kotest.engine.listener.CollectingTestEngineListener
 import io.kotest.engine.test.TestResult
-import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertAll
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import org.junit.BeforeClass
+import org.junit.Test
 import kotlin.reflect.KClass
 
 class AndroidTest {
     companion object {
-        @BeforeAll
+        @BeforeClass
+        @JvmStatic
         fun setup() {
-            KottageSpec.context = contextOf(InstrumentationRegistry.getInstrumentation().context)
+            KottageSpec._context = contextOf(InstrumentationRegistry.getInstrumentation().context)
         }
     }
 
     @Test
-    suspend fun kottageCacheTest() {
+    fun kottageCacheTest() = runTest {
         executeTest(KottageCacheTest::class)
     }
 
     @Test
-    suspend fun kottageEventTest() {
+    fun kottageEventTest() = runTest {
         executeTest(KottageEventTest::class)
     }
 
     @Test
-    suspend fun kottageListTest() {
+    fun kottageListTest() = runTest {
         executeTest(KottageListTest::class)
     }
 
     @Test
-    suspend fun kottageMigrationTest() {
+    fun kottageMigrationTest() = runTest {
         executeTest(KottageMigrationTest::class)
     }
 
     @Test
-    suspend fun kottageTest() {
+    fun kottageTest() = runTest {
         executeTest(KottageTest::class)
     }
 
@@ -55,8 +58,8 @@ class AndroidTest {
             .withListener(listener)
             .withSpecRefs(SpecRef.Reference(targetClass))
             .execute()
-        listener.tests.map { entry ->
-            {
+        assertSoftly {
+            for (entry in listener.tests) {
                 val testCase = entry.key
                 val descriptor = testCase.descriptor.path().value
                 val cause = when (val value = entry.value) {
@@ -64,13 +67,13 @@ class AndroidTest {
                     is TestResult.Failure -> value.cause
                     else -> null
                 }
-                assertFalse(entry.value.isErrorOrFailure) {
+                withClue({
                     """$descriptor
                     |${cause?.stackTraceToString()}""".trimMargin()
+                }) {
+                    entry.value.isErrorOrFailure shouldBe false
                 }
             }
-        }.let {
-            assertAll(it)
         }
         println("${targetClass.simpleName} Total ${listener.tests.size}, Failure ${listener.tests.count { it.value.isErrorOrFailure }}")
     }

--- a/kottage/src/commonTest/kotlin/io/github/irgaly/kottage/KottageMigrationTest.kt
+++ b/kottage/src/commonTest/kotlin/io/github/irgaly/kottage/KottageMigrationTest.kt
@@ -1,6 +1,5 @@
 package io.github.irgaly.kottage
 
-import io.github.irgaly.kottage.platform.KottageContext
 import io.github.irgaly.kottage.platform.TestCalendar
 import io.github.irgaly.kottage.test.KottageSpec
 import io.kotest.matchers.shouldBe
@@ -11,7 +10,7 @@ class KottageMigrationTest : KottageSpec("migration", body = {
     describe("Database Migration") {
         context("to latest") {
             val calendar = TestCalendar(DateTime(2022, 1, 1).utc)
-            val environment = KottageEnvironment(KottageContext(), calendar)
+            val environment = KottageEnvironment(getContext(), calendar)
             it("from 1") {
                 Kottage.createOldDatabase("v1", tempDirectory, environment, 1)
                 val kottage = Kottage("v1", tempDirectory, environment, specScope)

--- a/kottage/src/commonTest/kotlin/io/github/irgaly/kottage/KottageTest.kt
+++ b/kottage/src/commonTest/kotlin/io/github/irgaly/kottage/KottageTest.kt
@@ -1,12 +1,11 @@
 package io.github.irgaly.kottage
 
 import io.github.irgaly.kottage.encoder.KottageEncoder
-import io.github.irgaly.kottage.platform.KottageContext
 import io.github.irgaly.kottage.platform.Platform
 import io.github.irgaly.kottage.platform.TestCalendar
 import io.github.irgaly.kottage.property.KottageStore
 import io.github.irgaly.kottage.test.KottageSpec
-import io.kotest.assertions.retry
+import io.kotest.assertions.nondeterministic.eventually
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
@@ -20,7 +19,6 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerializationException
 import kotlin.experimental.xor
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 class KottageTest : KottageSpec("kottage", body = {
@@ -74,7 +72,7 @@ class KottageTest : KottageSpec("kottage", body = {
                             "_'_\"_\\_ _あ_😄_:_".sanitizePath()
                         }",
                         KottageEnvironment(
-                            KottageContext(),
+                            getContext(),
                             TestCalendar(DateTime(2022, 1, 1).utc)
                         ),
                         specScope
@@ -87,7 +85,7 @@ class KottageTest : KottageSpec("kottage", body = {
                         "test_'_\"_\\_ _あ_😄_:_".sanitizePath(),
                         tempDirectory,
                         KottageEnvironment(
-                            KottageContext(),
+                            getContext(),
                             TestCalendar(DateTime(2022, 1, 1).utc)
                         ),
                         specScope
@@ -100,7 +98,7 @@ class KottageTest : KottageSpec("kottage", body = {
                         "test_/_:_\\_",
                         tempDirectory,
                         KottageEnvironment(
-                            KottageContext(),
+                            getContext(),
                             TestCalendar(DateTime(2022, 1, 1).utc)
                         ),
                         specScope
@@ -135,7 +133,7 @@ class KottageTest : KottageSpec("kottage", body = {
                 storage.put("test", "test")
                 kottage.closed shouldBe false
                 scope.cancel()
-                retry(10, 10.seconds, delay = 100.milliseconds) {
+                eventually(10.seconds) {
                     // GlobalScope で Kottage.close() が処理されるため、処理完了まで非同期で待つ
                     kottage.closed shouldBe true
                     shouldThrow<IllegalStateException> {

--- a/kottage/src/commonTest/kotlin/io/github/irgaly/kottage/test/KottageSpec.kt
+++ b/kottage/src/commonTest/kotlin/io/github/irgaly/kottage/test/KottageSpec.kt
@@ -29,7 +29,12 @@ open class KottageSpec(
     constructor() : this("KottageSpec::dummy")
 
     companion object {
-        var context: KottageContext = KottageContext()
+        var _context: KottageContext? = null
+        fun getContext(): KottageContext {
+            return _context ?: KottageContext().also {
+                _context = it
+            }
+        }
     }
 
     val tempDirectory: String
@@ -52,7 +57,7 @@ open class KottageSpec(
     fun kottage(
         name: String = this.name,
         scope: CoroutineScope = specScope,
-        context: KottageContext = Companion.context,
+        context: KottageContext = getContext(),
         builder: (KottageOptions.Builder.() -> Unit)? = null
     ): Pair<Kottage, TestCalendar> = buildKottage(name, tempDirectory, scope, context, builder)
 
@@ -60,7 +65,7 @@ open class KottageSpec(
         name: String,
         directory: String,
         scope: CoroutineScope,
-        context: KottageContext = Companion.context,
+        context: KottageContext = getContext(),
         builder: (KottageOptions.Builder.() -> Unit)? = null
     ): Pair<Kottage, TestCalendar> {
         return io.github.irgaly.kottage.extension.buildKottage(


### PR DESCRIPTION
android-junit-frameworkが新しいKMP Android Library pluginに対応しないため、構成を変更する

* Android Device Test: android-junit-framework + JUnit5 + Kotest

↓

* Android Device Test: JUnit4 + Kotest